### PR TITLE
Change name in top-level places from iati.core to pyIATI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# iati.core
+# pyIATI
 
-The iati.core Python module.
+A developers’ toolkit for IATI.
 
 [![Build Status](https://travis-ci.org/IATI/iati.core.svg?branch=master)](https://travis-ci.com/IATI/iati.core) [![Requirements Status](https://requires.io/github/IATI/iati.core/requirements.svg?branch=master)](https://requires.io/github/IATI/iati.core/requirements/?branch=master)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'iati.core',
+    name = 'pyIATI',
     version = '0.1.0',
     description = 'Python library representing the IATI Schemas, Codelists and Rulesets',
     author = 'IATI Technical Team and other authors',


### PR DESCRIPTION
This is in-line with other ways that the library is being referenced.