### PR TITLE
Add missing lxml to travis install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ jobs:
           if: branch=dev
         - stage: strict lint
           python: 3.5
-          install: pip install pylint lxml
+          install:
+            - pip install -U pip wheel
+            - pip install -r requirements-dev.txt
           env: LINTER=pylint
           script: make pylint
           if: branch=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
           if: branch=dev
         - stage: strict lint
           python: 3.5
-          install: pip install pylint
+          install: pip install pylint lxml
           env: LINTER=pylint
           script: make pylint
           if: branch=master


### PR DESCRIPTION
The tests (eg. https://travis-ci.org/IATI/pyIATI/jobs/289934687) to merge into `master` are failing because of a missing dependency in a specific test that only runs when merging into master.