### PR TITLE
Add resources folder to package distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+- [Deployment] Include resource data in package distribution [#195].
+
 ### Security
 
 ## [0.1.0] - 2017-10-19

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include iati/resources *.*

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author_email = 'code@iatistandard.org',
     url='http://iatistandard.org/',
     packages = find_packages(exclude='iati/tests'),
+    include_package_data = True,
     install_requires = [
         # JSON schema parsing validation
         'jsonschema==2.6.0',


### PR DESCRIPTION
The source distribution package requires that a MANIFEST.in file
is added to the respoitory, to ensure that the resources folder
is shipped with the code.

This change is tested locally using `python setup.py sdist`, which results in a `dist/pyIATI-0.1.0.tar.gz` file, which – when uncompressed – contains the folder `iati/resources`.