### PR TITLE
Fix exclude pattern in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author = 'IATI Technical Team and other authors',
     author_email = 'code@iatistandard.org',
     url='http://iatistandard.org/',
-    packages = find_packages(exclude='iati/tests'),
+    packages = find_packages(),
     include_package_data = True,
     install_requires = [
         # JSON schema parsing validation


### PR DESCRIPTION
It was decided to not remove the tests folder from sdist packaging.
This will enable unpackaging for tests to be run before uploading a
planned release to pypi.