### PR TITLE
Convert 'xml:lang' attribute to use namespace when performing Codelist checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+- [Validation] Datasets with an `xml:lang` attribute no longer raise a `KeyError` upon performing Codelist validation against a Schema populated with the Language Codelist. [#226]
+
 ### Security
 
 

--- a/iati/resources/test_data/202/valid_iati_use_xml_lang.xml
+++ b/iati/resources/test_data/202/valid_iati_use_xml_lang.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<iati-activities version="2.02">
+  <iati-activity xml:lang="en">
+    <iati-identifier></iati-identifier>
+    <reporting-org type="40" ref="AA-AAA-123456789">
+      <narrative>Organisation name</narrative>
+      <narrative xml:lang="fr">Nom de l'organisme</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Xxxxxxx</narrative>
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative>
+    </description>
+    <participating-org role="2"></participating-org>
+    <activity-status code="2"/>
+    <activity-date type="1" iso-date="2023-11-27"/>
+  </iati-activity>
+</iati-activities>

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -704,10 +704,12 @@ class TestValidationCodelist(ValidateCodelistsBase):
         assert iati.validator.is_iati_xml(data, schema_incomplete_codelist)
         assert iati.validator.is_valid(data, schema_incomplete_codelist)
 
-    def test_basic_validation_short_mapping_xpath(self, schema_short_mapping_codelist):
+    @pytest.mark.parametrize('data', [
+        iati.tests.utilities.load_as_dataset('valid_iati'),
+        iati.tests.utilities.load_as_dataset('valid_iati_use_xml_lang')
+    ])
+    def test_basic_validation_short_mapping_xpath(self, schema_short_mapping_codelist, data):
         """Perform data validation against valid IATI XML. The attribute being tested refers to a Codelist with an abnormally short mapping file path. The data has no attributes mapped to by the Codelist."""
-        data = iati.tests.utilities.load_as_dataset('valid_iati')
-
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_short_mapping_codelist)
         assert iati.validator.is_valid(data, schema_short_mapping_codelist)

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -303,6 +303,9 @@ def _check_codes(dataset, codelist):
             parent_el_xpath = '/' + parent_el_xpath
         if parent_el_xpath.startswith('//['):
             parent_el_xpath = '//*[' + parent_el_xpath[3:]
+        # provide a secondary cludge to deal with the 'xml' namespace
+        if attr_name == 'xml:lang':
+            attr_name = '{http://www.w3.org/XML/1998/namespace}lang'
 
         parents_to_check = dataset.xml_tree.xpath(parent_el_xpath)
 


### PR DESCRIPTION
This is a fix to the bug identified by @andylolz in https://github.com/IATI/pyIATI/pull/45#issuecomment-342554472 - Codelist validation would raise a key error for any dataset with an `xml:lang` attribute.

This is a specific fix to the `xml:lang` problem. It does not address the issues that the current code does not support custom namespaces (though this is a larger problem).