### PR TITLE
Test for and document undocumented potential ValueErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [Codelists] Fixed impossible XPath in Codelist Mapping File. [IATI/IATI-Codelists#119]
 
+- [Defaults] Test and document `ValueError`s that can be raised by functions in `iati.default`. [#241]
+
 - [Validation] Prevent `XPathEvalError`s occurring when given a Codelist Mapping XPath that identifies something other than an attribute. [#229]
 - [Validation] Datasets with an `xml:lang` attribute no longer raise a `KeyError` upon performing Codelist validation against a Schema populated with the Language Codelist. [#226]
 

--- a/iati/default.py
+++ b/iati/default.py
@@ -140,6 +140,9 @@ def codelists(version=None):
     Args:
         version (str): The version of the Standard to return the Codelists for. Defaults to None. This means that the latest version of the Codelists are returned.
 
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
+
     Returns:
         dict: A dictionary containing all the Codelists at the specified version of the Standard. All Non-Embedded Codelists are included. Keys are Codelist names. Values are iati.Codelist() instances, populated with the relevant Codes.
 
@@ -152,6 +155,9 @@ def codelist_mapping(version=None):
 
     Args:
         version (str): The version of the Standard to return the mapping file for. Defaults to None. This means that the mapping file is returned for the latest version of the Standard.
+
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
         dict of dict: A dictionary containing mapping information. Keys in the first dictionary are Codelist names. Keys in the second dictionary are `xpath` and `condition`. The condition is `None` if there is no condition.
@@ -187,11 +193,11 @@ def ruleset(version=None):
     Args:
         version (str): The version of the Standard to return the Ruleset for. Defaults to None. This means that the latest Standard Ruleset is returned.
 
-    Returns:
-        iati.Ruleset: The default Ruleset for the specified version of the Standard.
-
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
+
+    Returns:
+        iati.Ruleset: The default Ruleset for the specified version of the Standard.
 
     """
     path = iati.resources.get_ruleset_path(iati.resources.FILE_RULESET_STANDARD_NAME, version)
@@ -206,11 +212,11 @@ def ruleset_schema(version=None):
     Args:
         version (str): The version of the Standard to return the Ruleset for. Defaults to None. This means that the latest Ruleset schema is returned.
 
-    Returns:
-        dict: A dictionary representing the Ruleset schema for the specified version of the Standard.
-
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
+
+    Returns:
+        dict: A dictionary representing the Ruleset schema for the specified version of the Standard.
 
     """
     path = iati.resources.get_ruleset_path(iati.resources.FILE_RULESET_SCHEMA_NAME, version)

--- a/iati/tests/test_default.py
+++ b/iati/tests/test_default.py
@@ -14,6 +14,9 @@ class TestDefault(object):
     @pytest.mark.parametrize("func_to_check", [
         iati.default.get_default_version_if_none,
         iati.default.codelists,
+        iati.default.codelist_mapping,
+        iati.default.ruleset,
+        iati.default.ruleset_schema,
         iati.default.activity_schema,
         iati.default.organisation_schema
     ])


### PR DESCRIPTION
Some, but not all, functions in iati.default had it documented and tested that the error could be raised.
This makes the documentation and testing more comprehensive.