### PR TITLE
Fix Codelist hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 
 - [Codelists] `complete` attribute included in equality comparison and hash calculations. [#247]
+- [Codelists] Codes must have a value to instantiate. [#247]
 
 - [Resources] Move `load_as_x` functions to `iati.utilities`. [#235]
 - [Resources] Rename version-specific resource folders to reduce ambiguity. [#217]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 
 - [Codelists] Fixed impossible XPath in Codelist Mapping File. [IATI/IATI-Codelists#119, #229]
+- [Codelists] Sort Codes in a Codelist before hashing so that Codelists with the same Codes always have the same hash. [#247]
 
 - [Defaults] Test and document `ValueError`s that can be raised by functions in `iati.default`. [#241]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
+- [Codelists] `complete` attribute included in equality comparison and hash calculations. [#247]
+
 - [Resources] Move `load_as_x` functions to `iati.utilities`. [#235]
 - [Resources] Rename version-specific resource folders to reduce ambiguity. [#217]
 

--- a/iati/codelists.py
+++ b/iati/codelists.py
@@ -105,7 +105,7 @@ class Codelist(object):
             Utilise all attributes as part of the equality process.
 
         """
-        return ((self.name) == (other.name)) and (collections.Counter(self.codes) == collections.Counter(other.codes))
+        return (self.name == other.name) and (self.complete == other.complete) and (collections.Counter(self.codes) == collections.Counter(other.codes))
 
     def __ne__(self, other):
         """Check Codelist inequality.
@@ -127,7 +127,7 @@ class Codelist(object):
         """
         sorted_codes = sorted(self.codes, key=lambda x: x.value)
 
-        return hash((self.name, tuple(sorted_codes)))
+        return hash((self.name, self.complete, tuple(sorted_codes)))
 
     @property
     def xsd_restriction(self):

--- a/iati/codelists.py
+++ b/iati/codelists.py
@@ -183,12 +183,12 @@ class Code(object):
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, value=None, name=''):
+    def __init__(self, value, name=''):
         """Initialise a Code.
 
         Args:
-            name (str): The name of the code being initialised.
             value (str): The value of the code being initialised.
+            name (str): The name of the code being initialised.
 
         Note:
             Instances of a Code should remain independent of a particular version of the IATI Standard. Versioning should be handled elsewhere.

--- a/iati/codelists.py
+++ b/iati/codelists.py
@@ -125,7 +125,9 @@ class Codelist(object):
             Utilise all attributes as part of the equality process.
 
         """
-        return hash((self.name, tuple(self.codes)))
+        sorted_codes = sorted(self.codes, key=lambda x: x.value)
+
+        return hash((self.name, tuple(sorted_codes)))
 
     @property
     def xsd_restriction(self):

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -197,7 +197,10 @@ class TestCodelistEquality(object):
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_name_not_equal(self, codelist, cmp_func_different):
-        """Check that two Codelist with the same codes but different names are not deemed to be equal."""
+        """Check that two different Codelists are not deemed to be equal.
+
+        The two Codelists have different names, but are otherwise identical.
+        """
         codelist_copy = copy.deepcopy(codelist)
         codelist_copy.name = codelist.name + 'with a difference'
 
@@ -205,7 +208,10 @@ class TestCodelistEquality(object):
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_completeness_not_equal(self, codelist, cmp_func_different):
-        """Check that two Codelist with the same codes but different completeness are not deemed to be equal."""
+        """Check that two different Codelists are not deemed to be equal.
+
+        The two Codelists have different completeness, but are otherwise identical.
+        """
         codelist_copy = copy.deepcopy(codelist)
         codelist_copy.complete = not codelist.complete
 
@@ -213,7 +219,10 @@ class TestCodelistEquality(object):
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_num_codes_not_equal(self, codelist, cmp_func_different):
-        """Check that two Codelist with the same name but different codes are not deemed to be equal."""
+        """Check that two different Codelists are not deemed to be equal.
+
+        One Codelist contains a Code that the other does not, but they are otherwise identical.
+        """
         codelist_copy = copy.deepcopy(codelist)
         codelist_copy.codes.add(iati.Code(''))
 
@@ -221,7 +230,10 @@ class TestCodelistEquality(object):
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_code_name_not_equal(self, codelist):
-        """Check that two Codelist with the same name but a Code with a different name are not deemed to be equal."""
+        """Check that two different Codelists are not deemed to be equal.
+
+        One contained Code has a different name, but the Codelists are otherwise identical.
+        """
         codelist_copy = copy.deepcopy(codelist)
         code = codelist_copy.codes.pop()
         code.name = code.name + 'with a difference'
@@ -232,7 +244,12 @@ class TestCodelistEquality(object):
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_code_name_same_hash(self, codelist):
-        """Check that two Codelist with the same name but a Code with a different name have the same hash."""
+        """Check that two not-equal Codelists are deemed to have the same hash.
+
+        One contained Code has a different name, but the Codelists are otherwise identical.
+
+        The hash should be the same since the important part of a `Code` is the `value` attribute. The name is not deemed to change its hash.
+        """
         codelist_copy = copy.deepcopy(codelist)
         code = codelist_copy.codes.pop()
         code.name = code.name + 'with a difference'
@@ -242,7 +259,10 @@ class TestCodelistEquality(object):
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_code_value_not_equal(self, codelist, cmp_func_different):
-        """Check that two Codelist with the same name but a Code with a different value are not deemed to be equal."""
+        """Check that two different Codelists are not deemed to be equal.
+
+        One contained Code has a different value, but the Codelists are otherwise identical.
+        """
         codelist_copy = copy.deepcopy(codelist)
         code = codelist_copy.codes.pop()
         code.value = code.value + 'with a difference'

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -167,6 +167,7 @@ class TestCodelistEquality(object):
 
     @pytest.fixture(params=[
         lambda x, y: x == y,
+        lambda x, y: y == x,
         lambda x, y: hash(x) == hash(y)
     ])
     def cmp_func_equal(self, request):
@@ -175,6 +176,7 @@ class TestCodelistEquality(object):
 
     @pytest.fixture(params=[
         lambda x, y: x != y,
+        lambda x, y: y != x,
         lambda x, y: hash(x) != hash(y)
     ])
     def cmp_func_different(self, request):
@@ -226,6 +228,7 @@ class TestCodelistEquality(object):
         codelist_copy.codes.add(code)
 
         assert codelist != codelist_copy
+        assert codelist_copy != codelist
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_code_name_same_hash(self, codelist):

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -45,8 +45,7 @@ class TestCodelists(object):
     def test_codelist_add_code(self, name_to_set):
         """Check a Code can be added to a Codelist."""
         codelist = iati.Codelist(name_to_set)
-        code = iati.Code()
-        codelist.codes.add(code)
+        codelist.codes.add(iati.Code(''))
 
         num_codes = len(codelist.codes)
 
@@ -123,12 +122,10 @@ class TestCodelists(object):
 class TestCodes(object):
     """A container for tests relating to Codes."""
 
-    def test_code_default_attributes(self):
-        """Check a Code's default attributes are correct."""
-        code = iati.Code()
-
-        assert code.name == ''
-        assert code.value is None
+    def test_code_no_attributes(self):
+        """Check a Code cannot be instantiated with no arguments."""
+        with pytest.raises(TypeError):
+            _ = iati.Code()
 
     def test_code_value_instance(self):
         """Check a Code's attributes are correct when being defined with only a value."""
@@ -216,7 +213,7 @@ class TestCodelistEquality(object):
     def test_codelist_diff_num_codes_not_equal(self, codelist, cmp_func_different):
         """Check that two Codelist with the same name but different codes are not deemed to be equal."""
         codelist_copy = copy.deepcopy(codelist)
-        codelist_copy.codes.add(iati.Code())
+        codelist_copy.codes.add(iati.Code(''))
 
         assert cmp_func_different(codelist, codelist_copy)
 

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -166,35 +166,51 @@ class TestCodes(object):
 
 
 class TestCodelistEquality(object):
-    """A container for tests relating to Codelist equality."""
+    """A container for tests relating to Codelist equality - both direct and via hashing."""
+
+    @pytest.fixture(params=[
+        lambda x, y: x == y,
+        lambda x, y: hash(x) == hash(y)
+    ])
+    def cmp_func_equal(self, request):
+        """Return a comparison function that checks whether things are equal."""
+        return request.param
+
+    @pytest.fixture(params=[
+        lambda x, y: x != y,
+        lambda x, y: hash(x) != hash(y)
+    ])
+    def cmp_func_different(self, request):
+        """Return a comparison function that checks whether things are different."""
+        return request.param
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
-    def test_codelist_same_object_equal(self, codelist):
+    def test_codelist_same_object_equal(self, codelist, cmp_func_equal):
         """Check that a Codelist is deemed to be equal with itself."""
-        assert codelist == codelist
+        assert cmp_func_equal(codelist, codelist)
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
-    def test_codelist_same_diff_object_equal(self, codelist):
+    def test_codelist_same_diff_object_equal(self, codelist, cmp_func_equal):
         """Check that two instances of the same Codelist are deemed to be equal."""
         codelist_copy = copy.deepcopy(codelist)
 
-        assert codelist == codelist_copy
+        assert cmp_func_equal(codelist, codelist_copy)
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
-    def test_codelist_diff_name_not_equal(self, codelist):
+    def test_codelist_diff_name_not_equal(self, codelist, cmp_func_different):
         """Check that two Codelist with the same codes but different names are not deemed to be equal."""
         codelist_copy = copy.deepcopy(codelist)
         codelist_copy.name = codelist.name + 'with a difference'
 
-        assert codelist != codelist_copy
+        assert cmp_func_different(codelist, codelist_copy)
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
-    def test_codelist_diff_num_codes_not_equal(self, codelist):
+    def test_codelist_diff_num_codes_not_equal(self, codelist, cmp_func_different):
         """Check that two Codelist with the same name but different codes are not deemed to be equal."""
         codelist_copy = copy.deepcopy(codelist)
         codelist_copy.codes.add(iati.Code())
 
-        assert codelist != codelist_copy
+        assert cmp_func_different(codelist, codelist_copy)
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_code_name_not_equal(self, codelist):
@@ -207,11 +223,21 @@ class TestCodelistEquality(object):
         assert codelist != codelist_copy
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
-    def test_codelist_diff_code_value_not_equal(self, codelist):
+    def test_codelist_diff_code_name_same_hash(self, codelist):
+        """Check that two Codelist with the same name but a Code with a different name have the same hash."""
+        codelist_copy = copy.deepcopy(codelist)
+        code = codelist_copy.codes.pop()
+        code.name = code.name + 'with a difference'
+        codelist_copy.codes.add(code)
+
+        assert hash(codelist) == hash(codelist_copy)
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_diff_code_value_not_equal(self, codelist, cmp_func_different):
         """Check that two Codelist with the same name but a Code with a different value are not deemed to be equal."""
         codelist_copy = copy.deepcopy(codelist)
         code = codelist_copy.codes.pop()
         code.value = code.value + 'with a difference'
         codelist_copy.codes.add(code)
 
-        assert codelist != codelist_copy
+        assert cmp_func_different(codelist, codelist_copy)

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -1,4 +1,5 @@
 """A module containing tests for the library representation of Codelists."""
+import copy
 import pytest
 from lxml import etree
 import iati.codelists
@@ -162,3 +163,55 @@ class TestCodes(object):
         assert enum_el.tag == iati.constants.NAMESPACE + 'enumeration'
         assert enum_el.attrib['value'] == value_to_set
         assert enum_el.nsmap == iati.constants.NSMAP
+
+
+class TestCodelistEquality(object):
+    """A container for tests relating to Codelist equality."""
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_same_object_equal(self, codelist):
+        """Check that a Codelist is deemed to be equal with itself."""
+        assert codelist == codelist
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_same_diff_object_equal(self, codelist):
+        """Check that two instances of the same Codelist are deemed to be equal."""
+        codelist_copy = copy.deepcopy(codelist)
+
+        assert codelist == codelist_copy
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_diff_name_not_equal(self, codelist):
+        """Check that two Codelist with the same codes but different names are not deemed to be equal."""
+        codelist_copy = copy.deepcopy(codelist)
+        codelist_copy.name = codelist.name + 'with a difference'
+
+        assert codelist != codelist_copy
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_diff_num_codes_not_equal(self, codelist):
+        """Check that two Codelist with the same name but different codes are not deemed to be equal."""
+        codelist_copy = copy.deepcopy(codelist)
+        codelist_copy.codes.add(iati.Code())
+
+        assert codelist != codelist_copy
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_diff_code_name_not_equal(self, codelist):
+        """Check that two Codelist with the same name but a Code with a different name are not deemed to be equal."""
+        codelist_copy = copy.deepcopy(codelist)
+        code = codelist_copy.codes.pop()
+        code.name = code.name + 'with a difference'
+        codelist_copy.codes.add(code)
+
+        assert codelist != codelist_copy
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_diff_code_value_not_equal(self, codelist):
+        """Check that two Codelist with the same name but a Code with a different value are not deemed to be equal."""
+        codelist_copy = copy.deepcopy(codelist)
+        code = codelist_copy.codes.pop()
+        code.value = code.value + 'with a difference'
+        codelist_copy.codes.add(code)
+
+        assert codelist != codelist_copy

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -125,7 +125,7 @@ class TestCodes(object):
     def test_code_no_attributes(self):
         """Check a Code cannot be instantiated with no arguments."""
         with pytest.raises(TypeError):
-            _ = iati.Code()
+            _ = iati.Code()  # pylint: disable=no-value-for-parameter
 
     def test_code_value_instance(self):
         """Check a Code's attributes are correct when being defined with only a value."""

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -205,6 +205,14 @@ class TestCodelistEquality(object):
         assert cmp_func_different(codelist, codelist_copy)
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
+    def test_codelist_diff_completeness_not_equal(self, codelist, cmp_func_different):
+        """Check that two Codelist with the same codes but different completeness are not deemed to be equal."""
+        codelist_copy = copy.deepcopy(codelist)
+        codelist_copy.complete = not codelist.complete
+
+        assert cmp_func_different(codelist, codelist_copy)
+
+    @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())
     def test_codelist_diff_num_codes_not_equal(self, codelist, cmp_func_different):
         """Check that two Codelist with the same name but different codes are not deemed to be equal."""
         codelist_copy = copy.deepcopy(codelist)


### PR DESCRIPTION
Codelists contain Codes within a set. This means that they are in no particular order. Hash functions require input in the same order to produce the same output.

This sorts the Codes in a Codelist before hashing so that Codelists with the same Codes hash the same no matter which order the set provides them in.