### PR TITLE
Change Rule's `name` attribute to property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [Defaults] Test and document `ValueError`s that can be raised by functions in `iati.default`. [#241]
 
+- [Rulesets] `name` attribute on a Rule changed to read-only property. [#251]
+
 - [Validation] Prevent `XPathEvalError`s occurring when given a Codelist Mapping XPath that identifies something other than an attribute. [#229]
 - [Validation] Datasets with an `xml:lang` attribute no longer raise a `KeyError` upon performing Codelist validation against a Schema populated with the Language Codelist. [#226]
 

--- a/iati/rulesets.py
+++ b/iati/rulesets.py
@@ -152,7 +152,6 @@ class Rule(object):
     Acts as a base class for specific types of Rule that actually check the content of the data.
 
     Attributes:
-        name (str): The type of Rule, as specified in a JSON Ruleset.
         context (str): An XPath expression to locate the elements that the Rule is to be checked against.
         case (dict): Specific configuration for this instance of the Rule.
 
@@ -182,6 +181,11 @@ class Rule(object):
     def __str__(self):
         """Return string to state what the Rule is checking."""
         return 'This is a Rule.'
+
+    @property
+    def name(self):
+        """str: The type of Rule, as specified in a JSON Ruleset."""
+        return self._name
 
     def _validated_context(self, context):
         """Check that a valid `context` is given for a Rule.
@@ -434,7 +438,7 @@ class RuleAtLeastOne(Rule):
 
     def __init__(self, context, case):
         """Initialise an `atleast_one` rule."""
-        self.name = 'atleast_one'
+        self._name = 'atleast_one'
 
         super(RuleAtLeastOne, self).__init__(context, case)
 
@@ -499,7 +503,7 @@ class RuleDateOrder(Rule):
 
     def __init__(self, context, case):
         """Initialise a `date_order` rule."""
-        self.name = 'date_order'
+        self._name = 'date_order'
         self.special_case = 'NOW'  # Was a constant sort of
 
         super(RuleDateOrder, self).__init__(context, case)
@@ -610,7 +614,7 @@ class RuleDependent(Rule):
 
     def __init__(self, context, case):
         """Initialise a `dependent` rule."""
-        self.name = 'dependent'
+        self._name = 'dependent'
 
         super(RuleDependent, self).__init__(context, case)
 
@@ -653,7 +657,7 @@ class RuleNoMoreThanOne(Rule):
 
     def __init__(self, context, case):
         """Initialise a `no_more_than_one` rule."""
-        self.name = 'no_more_than_one'
+        self._name = 'no_more_than_one'
 
         super(RuleNoMoreThanOne, self).__init__(context, case)
 
@@ -703,7 +707,7 @@ class RuleRegexMatches(Rule):
             ValueError: When the case does not contain valid regex.
 
         """
-        self.name = 'regex_matches'
+        self._name = 'regex_matches'
 
         super(RuleRegexMatches, self).__init__(context, case)
 
@@ -757,7 +761,7 @@ class RuleRegexNoMatches(Rule):
             ValueError: When the case does not contain valid regex.
 
         """
-        self.name = 'regex_no_matches'
+        self._name = 'regex_no_matches'
 
         super(RuleRegexNoMatches, self).__init__(context, case)
 
@@ -806,7 +810,7 @@ class RuleStartsWith(Rule):
 
     def __init__(self, context, case):
         """Initialise a `startswith` Rule."""
-        self.name = 'startswith'
+        self._name = 'startswith'
 
         super(RuleStartsWith, self).__init__(context, case)
 
@@ -865,7 +869,7 @@ class RuleSum(Rule):
 
     def __init__(self, context, case):
         """Initialise a `sum` rule."""
-        self.name = 'sum'
+        self._name = 'sum'
 
         super(RuleSum, self).__init__(context, case)
 
@@ -917,7 +921,7 @@ class RuleUnique(Rule):
 
     def __init__(self, context, case):
         """Initialise a `unique` rule."""
-        self.name = 'unique'
+        self._name = 'unique'
 
         super(RuleUnique, self).__init__(context, case)
 

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -337,7 +337,12 @@ class RuleSubclassFixtures(object):
 
 
 class RuleSubclassTestsGeneral(RuleSubclassFixtures):  # pylint: disable=too-many-public-methods
-    """A container for general tests for Rule subclasses."""
+    """A container for general tests for Rule subclasses.
+
+    Todo:
+        Where `rule_instantiating` is used, determine whether changing to `rule` would reduce the coverage of the test.
+
+    """
 
     def test_rule_init_valid_parameter_types(self, rule_instantiating):
         """Check that Rule subclasses can be instantiated with valid parameter types."""

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -247,8 +247,8 @@ class TestRuleSubclasses(object):
             rule_constructor(context, case)
 
 
-class RuleSubclassTestBase(object):  # pylint: disable=too-many-public-methods
-    """A base class for Rule subclass tests."""
+class RuleSubclassFixtures(object):
+    """A base class for fixtures to use in Rule subclass tests."""
 
     @pytest.fixture
     def valid_single_context(self):
@@ -329,6 +329,10 @@ class RuleSubclassTestBase(object):  # pylint: disable=too-many-public-methods
     def invalid_condition_rule(self, rule_constructor, valid_single_context, condition_is_true_invalid):
         """Return a Rule with a `condition`."""
         return rule_constructor(valid_single_context, condition_is_true_invalid)
+
+
+class RuleSubclassTestBase(RuleSubclassFixtures):  # pylint: disable=too-many-public-methods
+    """A base class for Rule subclass tests."""
 
     def test_rule_init_valid_parameter_types(self, rule_instantiating):
         """Check that Rule subclasses can be instantiated with valid parameter types."""

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -368,6 +368,11 @@ class RuleSubclassTestsGeneral(RuleSubclassFixtures):  # pylint: disable=too-man
         """Check that a Rule subclass has the expected name."""
         assert rule_instantiating.name == rule_type
 
+    def test_rule_name_cannot_be_set(self, rule):
+        """Check that a Rule subclass cannot have its name changed after instantiation."""
+        with pytest.raises(AttributeError):
+            rule.name = 'a new name'
+
     def test_rule_string_output_general(self, rule_instantiating):
         """Check that the string format of the Rule has been customised and variables formatted."""
         assert 'iati.rulesets' not in str(rule_instantiating)

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -295,6 +295,11 @@ class RuleSubclassFixtures(object):
         condition_validating_case['condition'] = request.param
         return condition_validating_case
 
+    @pytest.fixture()
+    def rule(self, rule_constructor, valid_single_context, single_instantiating_case):
+        """A single instance of a Rule subclass."""
+        return rule_constructor(valid_single_context, single_instantiating_case)
+
     @pytest.fixture
     def rule_instantiating(self, rule_constructor, instantiating_case, valid_single_context):
         """Rule subclass that instantiates but is not used for validation testing."""
@@ -331,8 +336,8 @@ class RuleSubclassFixtures(object):
         return rule_constructor(valid_single_context, condition_is_true_invalid)
 
 
-class RuleSubclassTestBase(RuleSubclassFixtures):  # pylint: disable=too-many-public-methods
-    """A base class for Rule subclass tests."""
+class RuleSubclassTestsGeneral(RuleSubclassFixtures):  # pylint: disable=too-many-public-methods
+    """A container for general tests for Rule subclasses."""
 
     def test_rule_init_valid_parameter_types(self, rule_instantiating):
         """Check that Rule subclasses can be instantiated with valid parameter types."""
@@ -458,6 +463,15 @@ class RuleSubclassTestBase(RuleSubclassFixtures):  # pylint: disable=too-many-pu
             rule_constructor(valid_single_context, junk_condition_case)
 
 
+class RuleSubclassTestBase(RuleSubclassTestsGeneral):
+    """A base class for Rule subclass tests.
+
+    This allows particular types of Rule to inherit from a single class, while allowing for logical separation of blocks of tests.
+    """
+
+    pass
+
+
 class TestRuleAtLeastOne(RuleSubclassTestBase):
     """A container for tests relating to RuleAtLeastOne."""
 
@@ -497,6 +511,11 @@ class TestRuleAtLeastOne(RuleSubclassTestBase):
         {'paths': ['element7', 'element8']},  # multiple paths, both expected matches missing
         {'paths': ['element13/@attribute', 'element14/@attribute']}
     ]
+
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
 
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
@@ -630,6 +649,11 @@ class TestRuleDateOrder(RuleSubclassTestBase):
         """Type of Rule."""
         return 'date_order'
 
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
+
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
         """Permitted case for this Rule."""
@@ -762,6 +786,11 @@ class TestRuleDependent(RuleSubclassTestBase):
         """Type of Rule."""
         return 'dependent'
 
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
+
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
         """Permitted case for this Rule."""
@@ -854,6 +883,11 @@ class TestRuleNoMoreThanOne(RuleSubclassTestBase):
     def rule_type(self):
         """Type of Rule."""
         return 'no_more_than_one'
+
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
 
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
@@ -948,6 +982,11 @@ class TestRuleRegexMatches(RuleSubclassTestBase):
         """Type of Rule."""
         return 'regex_matches'
 
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
+
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
         """Permitted case for instatiating this Rule."""
@@ -1041,6 +1080,11 @@ class TestRuleRegexNoMatches(RuleSubclassTestBase):
         """Type of Rule."""
         return 'regex_no_matches'
 
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
+
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
         """Permitted case for instatiating this Rule."""
@@ -1132,6 +1176,11 @@ class TestRuleStartsWith(RuleSubclassTestBase):
     def rule_type(self):
         """Type of Rule."""
         return 'startswith'
+
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
 
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
@@ -1279,6 +1328,11 @@ class TestRuleSum(RuleSubclassTestBase):
         """Type of Rule."""
         return 'sum'
 
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
+
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):
         """Permitted case for instatiating this Rule."""
@@ -1373,6 +1427,11 @@ class TestRuleUnique(RuleSubclassTestBase):
     def rule_type(self):
         """Type of Rule."""
         return 'unique'
+
+    @pytest.fixture(params=[all_valid_cases[0]])
+    def single_instantiating_case(self, request):
+        """Single permitted case for instatiating this Rule."""
+        return request.param
 
     @pytest.fixture(params=all_valid_cases)
     def instantiating_case(self, request):


### PR DESCRIPTION
The `name` of a Rule should not be writable after instantiation.

This changes it from an attribute to a property so that this is the case.