### PR TITLE
Privatise Rule.case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [Resources] Rename version-specific resource folders to reduce ambiguity. [#217]
 
 - [Rulesets] `validate_ruleset()` changed from public to private function. [#246]
+- [Rulesets] `Rule.case` changed from public to private attribute. [#252]
 
 - [Validation] `_check_is_iati_xml()` will raise a `TypeError` when given a non-dataset. This replaces an undocumented `AttributeError`. [#239]
 

--- a/iati/rulesets.py
+++ b/iati/rulesets.py
@@ -165,7 +165,6 @@ class Rule(object):
 
         Args:
             context (str): An XPath expression to locate the elements that the Rule is to be checked against.
-            case (dict): Specific configuration for this instance of the Rule.
 
         Raises:
             TypeError: When a parameter is of an incorrect type.

--- a/iati/rulesets.py
+++ b/iati/rulesets.py
@@ -172,7 +172,7 @@ class Rule(object):
             ValueError: When a rule_type is not one of the permitted Rule types.
 
         """
-        self.case = case
+        self._case = case
         self.context = self._validated_context(context)
         self._valid_rule_configuration(case)
         self._set_case_attributes(case)

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -341,6 +341,8 @@ class RuleSubclassTestsGeneral(RuleSubclassFixtures):  # pylint: disable=too-man
     Todo:
         Where `rule_instantiating` is used, determine whether changing to `rule` would reduce the coverage of the test.
 
+        Test and ensure dynamically-created attributes (`less`, `more`, `paths`, etc) are not writable after instantiation.
+
     """
 
     def test_rule_init_valid_parameter_types(self, rule_instantiating):

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -1,7 +1,6 @@
 """A module containing tests for the library representation of Rulesets.
 
 Todo:
-    Remove references to `case`.
     Check all tests are still necessary/relevant.
     Condense tests for individual Rules.
     Try to standardise Rule arrays for extraction.


### PR DESCRIPTION
The values from within the case are extracted into their own properties. These can be accessed instead should the components be needed.

It should not be necessary to externally access the entire case of a Rule as an attribute. If good reason can be provided for why it does need accessing, it can be made public again.