### PR TITLE
Make a Rule's context read-only after init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [Resources] Rename version-specific resource folders to reduce ambiguity. [#217]
 
 - [Rulesets] `validate_ruleset()` changed from public to private function. [#246]
+- [Rulesets] `context` attribute on a Rule changed to read-only property. [#253]
 
 - [Validation] `_check_is_iati_xml()` will raise a `TypeError` when given a non-dataset. This replaces an undocumented `AttributeError`. [#239]
 

--- a/iati/rulesets.py
+++ b/iati/rulesets.py
@@ -164,7 +164,6 @@ class Rule(object):
         """Initialise a Rule.
 
         Args:
-            context (str): An XPath expression to locate the elements that the Rule is to be checked against.
             case (dict): Specific configuration for this instance of the Rule.
 
         Raises:
@@ -173,7 +172,7 @@ class Rule(object):
 
         """
         self.case = case
-        self.context = self._validated_context(context)
+        self._context = self._validated_context(context)
         self._valid_rule_configuration(case)
         self._set_case_attributes(case)
         self._normalize_xpaths()
@@ -181,6 +180,11 @@ class Rule(object):
     def __str__(self):
         """Return string to state what the Rule is checking."""
         return 'This is a Rule.'
+
+    @property
+    def context(self):
+        """str: An XPath expression to locate the elements that the Rule is to be checked against."""
+        return self._context
 
     @property
     def name(self):

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -378,6 +378,11 @@ class RuleSubclassTestsGeneral(RuleSubclassFixtures):  # pylint: disable=too-man
         with pytest.raises(AttributeError):
             rule.name = 'a new name'
 
+    def test_rule_context_cannot_be_set(self, rule):
+        """Check that a Rule subclass cannot have its context changed after instantiation."""
+        with pytest.raises(AttributeError):
+            rule.context = 'a-new-context'
+
     def test_rule_string_output_general(self, rule_instantiating):
         """Check that the string format of the Rule has been customised and variables formatted."""
         assert 'iati.rulesets' not in str(rule_instantiating)


### PR DESCRIPTION
Rules within a Ruleset should be unique. Being able to change the context impacts how this is done.

At the moment, common properties are being changed. Ones that change based on the specific Rule will be looked at separately.