### PR TITLE
Test that multiple Rulesets can be added to a Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [Utility] Non-resource files may be loaded using utility functions. [#235]
 
+- [Schemas] Test that multiple Rulesets can be added to a Schema. [#254]
+
 - [Validation] `full_validation()` now checks whether a Dataset is IATI XML. [#239]
 - [Validation] Test that SSOT organisation test files are valid IATI XML. [#242]
 

--- a/iati/tests/test_schemas.py
+++ b/iati/tests/test_schemas.py
@@ -1,5 +1,6 @@
 """A module containing tests for the library representation of Schemas."""
 # pylint: disable=protected-access
+import copy
 from lxml import etree
 import pytest
 import iati.codelists
@@ -208,20 +209,29 @@ class TestSchemas(object):
 
         assert len(schema_initialised.rulesets) == 1
 
-    @pytest.mark.skip(reason='Not implemented')
     def test_schema_rulesets_add_twice(self, schema_initialised):
-        """Check that it is not possible to add the same Rulesets to a Schema multiple times.
+        """Check that it is not possible to add the same Ruleset to a Schema multiple times.
 
         Todo:
             Consider if this test should test against a versioned Ruleset.
         """
-        raise NotImplementedError
+        ruleset = iati.default.ruleset()
 
-    @pytest.mark.skip(reason='Not implemented')
+        schema_initialised.rulesets.add(ruleset)
+        schema_initialised.rulesets.add(ruleset)
+
+        assert len(schema_initialised.rulesets) == 1
+
     def test_schema_rulesets_add_duplicate(self, schema_initialised):
-        """Check that it is not possible to add multiple functionally identical Rulesets to a Schema.
+        """Check that it is possible to add multiple functionally identical Rulesets to a Schema.
 
         Todo:
             Consider if this test should test against a versioned Ruleset.
         """
-        raise NotImplementedError
+        ruleset = iati.default.ruleset()
+        ruleset_copy = copy.deepcopy(ruleset)
+
+        schema_initialised.rulesets.add(ruleset)
+        schema_initialised.rulesets.add(ruleset_copy)
+
+        assert len(schema_initialised.rulesets) == 2

--- a/iati/tests/test_schemas.py
+++ b/iati/tests/test_schemas.py
@@ -235,3 +235,18 @@ class TestSchemas(object):
         schema_initialised.rulesets.add(ruleset_copy)
 
         assert len(schema_initialised.rulesets) == 2
+
+    def test_schema_rulesets_add_two_different(self, schema_initialised):
+        """Check that it is possible to add multiple different Rulesets to a Schema.
+
+        Todo:
+            Consider if this test should test against a versioned Ruleset.
+        """
+        ruleset = iati.default.ruleset()
+        ruleset_copy = copy.deepcopy(ruleset)
+        ruleset_copy.rules.pop()
+
+        schema_initialised.rulesets.add(ruleset)
+        schema_initialised.rulesets.add(ruleset_copy)
+
+        assert len(schema_initialised.rulesets) == 2


### PR DESCRIPTION
Multiple Rulesets can be added to a Schema now.

As such, the tests can be implemented rather than skipped.

A `not` has been removed due to the complications of handling mutable hashable objects - this is a thing that should be separately looked at properly.