### PR TITLE
Improve `version` argument in `**/resources.py`

### DIFF
--- a/iati/tests/test_resources.py
+++ b/iati/tests/test_resources.py
@@ -4,6 +4,7 @@ import pytest
 import iati.constants
 import iati.resources
 import iati.validator
+import iati.tests.resources
 
 
 class TestResources(object):
@@ -64,16 +65,26 @@ class TestResourceFolders(object):
         path = iati.resources.get_folder_path_for_version(*standard_version_optional)
         assert path_component in path
 
-    def test_get_test_data_paths_in_folder(self):
+    @pytest.mark.parametrize('version, expected_num_paths', [
+        ('2.02', 237),
+        ('2.01', 217),
+        ('1.05', 17),
+        ('1.04', 17),
+        ('1.03', 17),
+        ('1.02', 17),
+        ('1.01', 16),
+        ('1', 0),
+        ('2', 0),
+        (None, 0)
+    ])
+    def test_get_test_data_paths_in_folder(self, version, expected_num_paths):
         """Check that test data is being found in specified subfolders.
 
-        Todo:
-            Deal with multiple versions.
-
+        Look for the number of paths in the `ssot-activity-xml-fail` folder.
         """
-        paths = iati.tests.resources.get_test_data_paths_in_folder('ssot-activity-xml-fail', '2.02')
+        paths = iati.tests.resources.get_test_data_paths_in_folder('ssot-activity-xml-fail', version)
 
-        assert len(paths) == 237
+        assert len(paths) == expected_num_paths
 
 
 class TestResourceLibraryData(object):


### PR DESCRIPTION
Brings use of `version` argument in `**/resources.py` in line with #218 

---

## Tasks

### resources.py

#### `get_x_paths()`

- [ ] `get_codelist_paths()`
    - [ ] Version-independent: Number of NE Codelists relating to everything (to become Replicated)
    - [x] Integer: Number of NE Codelists relating to Integer
    - [x] Decimal: Number of Embedded and NE Codelists relating to version
- [x] `get_codelist_mapping_paths()`
    - [x] Version-independent: ValueError
    - [x] Integer: Number of Mapping Files for all Decimals at a given Integer
    - [x] Decimal: Number of Mapping Files at each version
- [x] `get_ruleset_paths()`
    - [x] Version-independent: ValueError
    - [x] Integer: Number of Rulesets for all Decimals in given Integer
    - [x] Decimal: Number of Rulesets at each version
- [x] `get_all_schema_paths()`
    - [x] Version-independent: ValueError
    - [x] Integer: Number of Schemas for all Decimals in given Integer
    - [x] Decimal: Number of Schemas at each version
- [x] `get_activity_schema_paths()`
    - [x] Version-independent: ValueError
    - [x] Integer: Number of Activity Schemas for all Decimals in given Integer
    - [x] Decimal: Number of Activity Schemas at each version
- [x] `get_organisation_schema_paths()`
    - [x] Version-independent: ValueError
    - [x] Integer: Number of Org Schemas for all Decimals in given Integer
    - [x] Decimal: Number of Org Schemas at each version

#### `create_x_path()` (see: https://github.com/IATI/pyIATI/pull/263)

- [x] `create_codelist_path()`
    - [x] Codelist name that exists at all versions
        - [x] All versions: A single path is returned
    - [x] Codelist name that exists at some versions
        - [x] All versions: A single path is returned
    - [x] Codelist name that exists at no versions
        - [x] All versions: A single path is returned
    - [x] Non-str name: TypeError
    - [x] Other version: ValueError
- [x] `create_codelist_mapping_path()`
    - [x] Version-independent: ValueError
    - [x] Integer: Most recent Decimal within the Integer
    - [x] Decimal: There is a single mapping at each version
    - [x] Other value: ValueError
- [x] `create_lib_data_path()`
    - [x] Does not take a `version` argument
- [x] `create_ruleset_path()`
    - [x] All versions: A single path is returned
    - [x] All versions: Contains required components
- [x] `create_schema_path()`
    - [x] All versions: A single path is returned
    - [x] All versions: Contains required components

#### `[folder|path]_for_x()`

- [x] `folder_name_for_version()`
    - [x] Expected output for each version
    - [x] Version-independent: `version-independent`
    - [x] Integer: `[integer]`
    - [x] Decimal: `[integer]-[decimal]`
- [x] `folder_name_for_version()`
    - [x] All versions: A single path is returned
    - [x] All versions: Contains required components
- [x] `path_for_version()`
    - [x] All versions: A single path is returned
    - [x] All versions: Contains required components

#### `pkg_resources` fun

- [x] `resource_filesystem_path()`
    - [x] All versions: A single path is returned
    - [x] All versions: Contains required components

### tests/resources.py

#### `get_test_x()`

- [ ] `get_test_data_path()`
    - [ ] Don't need to test directly
- [ ] `get_test_data_paths_in_folder()`
    - [ ] Number of files in a given folder
- [ ] `get_test_ruleset_path()`
    - [ ] To remove

#### `load_as_x()`

- [ ] `load_as_dataset()`
    - [ ] Ensure it returns a Dataset
- [ ] `load_as_string()`
    - [ ] Ensure it returns a string