### PR TITLE
Add a Minor versions constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 - [Constants] `STANDARD_VERSIONS_SUPPORTED` lists all versions of the Standard that are fully supported by pyIATI. [#223]
+- [Constants] `STANDARD_VERSIONS_MINOR` lists all Minor versions of the IATI Standard. [#264]
 
 - [Datasets] A Dataset `xml_tree` may be set with an ElementTree. [#235]
 

--- a/iati/constants.py
+++ b/iati/constants.py
@@ -31,6 +31,9 @@ STANDARD_VERSIONS_MAJOR = list(set([
 ]))
 """The major versions of the IATI Standard."""
 
+STANDARD_VERSIONS_MINOR = STANDARD_VERSIONS
+"""The minor versions of the IATI Standard."""
+
 LOG_FILE_NAME = 'iatilib.log'
 """The location of the primary IATI log file.
 

--- a/iati/tests/test_constants.py
+++ b/iati/tests/test_constants.py
@@ -8,7 +8,8 @@ class TestConstants(object):
 
     @pytest.fixture(params=[
         iati.constants.STANDARD_VERSIONS,
-        iati.constants.STANDARD_VERSIONS_SUPPORTED
+        iati.constants.STANDARD_VERSIONS_SUPPORTED,
+        iati.constants.STANDARD_VERSIONS_MINOR
     ])
     def standard_versions_list(self, request):
         """Return a list of Version Numbers."""

--- a/iati/tests/test_constants.py
+++ b/iati/tests/test_constants.py
@@ -55,3 +55,7 @@ class TestConstants(object):
     def test_standard_versions_major_correct_number(self):
         """Check that the correct number of major versions are detected."""
         assert len(iati.constants.STANDARD_VERSIONS_MAJOR) == 2
+
+    def test_standard_versions_minor_correct_number(self):
+        """Check that the correct number of minor versions are detected."""
+        assert len(iati.constants.STANDARD_VERSIONS_MINOR) == 7

--- a/iati/tests/test_constants.py
+++ b/iati/tests/test_constants.py
@@ -25,10 +25,15 @@ class TestConstants(object):
         assert isinstance(iati.constants.NSMAP['xsd'], str)
 
     def test_standard_versions_all_are_numbers(self, standard_versions_list):
-        """Check that each item in standard versions is a string that can be considered to be a decimal number."""
+        """Check that each item in standard versions is a string that can be considered to be a correctly formatted decimal number."""
         for version in standard_versions_list:
+            split_version = version.split('.')
+
             assert isinstance(version, str)
             assert float(version)
+            assert len(split_version) == 2
+            assert len(split_version[1]) == 2
+            assert version == version.strip()
 
     def test_standard_versions_correct_format(self, standard_versions_list):
         """Check that standard versions is in the correct format."""


### PR DESCRIPTION
This adds a constant to allow explicit specification of Minor versions.

This is partially preemptive of SemVer.
It also adds naming consistency with the equivalent constant for Major versions.

The relevant test has been improved.