### PR TITLE
Fix linting fail for check added with pylint 1.8

### DIFF
--- a/iati/rulesets.py
+++ b/iati/rulesets.py
@@ -598,7 +598,7 @@ class RuleDateOrder(Rule):
 
         dates = self._extract_text_from_element_or_attribute(context_element, path)
         if dates == list() or not dates[0]:
-            return
+            return None
         # Checks that anything after the YYYY-MM-DD string is a permitted timezone character
         pattern = re.compile(r'^([+-]([01][0-9]|2[0-3]):([0-5][0-9])|Z)?$')
         if (len(set(dates)) == 1) and pattern.match(dates[0][10:]):


### PR DESCRIPTION
The fixed error: `R:573, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)`