### PR TITLE
Run travis tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install -U pip wheel
   - pip install -r requirements-dev.txt
 script:
-  - make test
+  - make testp
 
 stages:
   - test


### PR DESCRIPTION
There is now a 30% speed increase when running tests in parallel locally.
Travis runs on 2-core containers, so this may provide a notable speedup.

https://travis-ci.org/IATI/pyIATI/builds/343745666 vs. (https://travis-ci.org/IATI/pyIATI/builds/343350773 and https://travis-ci.org/IATI/pyIATI/builds/342424174) shows that there is also a notable speedup on Travis.