### PR TITLE
Change constant meaning 'version independent' to not None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [Validation] `_check_is_iati_xml()` will raise a `TypeError` when given a non-dataset. This replaces an undocumented `AttributeError`. [#239]
 
+- [Versions] The value to represent 'version independent' has been changed to be a value that is `not None`, and a constant added to specify the exact value. [#281]
+
 ### Deprecated
 
 ### Removed

--- a/iati/resources.py
+++ b/iati/resources.py
@@ -57,11 +57,11 @@ FILE_SCHEMA_ORGANISATION_NAME = 'iati-organisations-schema'
 """The name of a file containing an Organisation Schema."""
 
 
-def get_codelist_paths(version=None):
+def get_codelist_paths(version=iati.version.STANDARD_VERSION_ANY):
     """Find the paths for all Codelists at the specified version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the Codelists for. Defaults to None. This means that paths to a version-independent version of the Codelists are returned.
+        version (str): The version of the Standard to return the Codelists for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
@@ -85,11 +85,11 @@ def get_codelist_paths(version=None):
     return paths
 
 
-def get_codelist_mapping_paths(version=None):
+def get_codelist_mapping_paths(version=iati.version.STANDARD_VERSION_ANY):
     """Find the paths for all Codelist Mapping files at the specified version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the Codelist Mapping file for. Defaults to None. This means that paths to the latest version of the Codelist Mapping file are returned.
+        version (str): The version of the Standard to return the Codelist Mapping file for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
@@ -108,11 +108,11 @@ def get_codelist_mapping_paths(version=None):
     return paths
 
 
-def get_ruleset_paths(version=None):
+def get_ruleset_paths(version=iati.version.STANDARD_VERSION_ANY):
     """Find the paths for all Rulesets at the specified version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the Rulesets for. Defaults to None. This means that paths to the latest version of the Rulesets are returned.
+        version (str): The version of the Standard to return the Rulesets for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
@@ -131,11 +131,11 @@ def get_ruleset_paths(version=None):
     return paths
 
 
-def get_all_schema_paths(version=None):
+def get_all_schema_paths(version=iati.version.STANDARD_VERSION_ANY):
     """Find the paths for all Schemas at the specified version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the Schemas for. Defaults to None. This means that paths to a version-independent version of the Schemas are returned.
+        version (str): The version of the Standard to return the Schemas for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
@@ -152,11 +152,11 @@ def get_all_schema_paths(version=None):
     return get_activity_schema_paths(version) + get_organisation_schema_paths(version)
 
 
-def get_activity_schema_paths(version=None):
+def get_activity_schema_paths(version=iati.version.STANDARD_VERSION_ANY):
     """Find the paths for all Activity Schemas at the specified version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the activity schemas for. Defaults to None. This means that paths to a version-independent version of the Activity Schemas are returned.
+        version (str): The version of the Standard to return the activity schemas for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
@@ -173,11 +173,11 @@ def get_activity_schema_paths(version=None):
     return [create_schema_path(FILE_SCHEMA_ACTIVITY_NAME, version)]
 
 
-def get_organisation_schema_paths(version=None):  # pylint: disable=invalid-name
+def get_organisation_schema_paths(version=iati.version.STANDARD_VERSION_ANY):  # pylint: disable=invalid-name
     """Find the paths for all Organisation Schemas at the specified version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the Organisation schemas for. Defaults to None. This means that paths to a version-independent version of the Organisation Schemas are returned.
+        version (str): The version of the Standard to return the Organisation schemas for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
@@ -195,12 +195,12 @@ def get_organisation_schema_paths(version=None):  # pylint: disable=invalid-name
     return [create_schema_path(FILE_SCHEMA_ORGANISATION_NAME, version)]
 
 
-def create_codelist_path(codelist_name, version=None):
+def create_codelist_path(codelist_name, version=iati.version.STANDARD_VERSION_ANY):
     """Determine the path of a Codelist with the given name at the specified version of the Standard.
 
     Args:
         codelist_name (str): The name of the codelist to locate. Should the name end in `.xml`, this shall be removed to determine the name.
-        version (str): The version of the Standard to return the Codelists for. Defaults to None. This means that a path to a version-independent version of the Codelist is returned.
+        version (str): The version of the Standard to return the Codelists for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The path to a file containing the specified Codelist.
@@ -218,10 +218,10 @@ def create_codelist_path(codelist_name, version=None):
     return path_for_version(os.path.join(PATH_CODELISTS, '{0}'.format(codelist_name) + FILE_CODELIST_EXTENSION), version)
 
 
-def create_codelist_mapping_path(version=None):
+def create_codelist_mapping_path(version=iati.version.STANDARD_VERSION_ANY):
     """Determine the path of the Codelist mapping file.
 
-    version (str): The version of the Standard to return the data files for. Defaults to None. This means that the path is returned for a filename independent of any version of the Standard.
+    version (str): The version of the Standard to return the data files for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The path to a file containing the mapping file.
@@ -248,12 +248,12 @@ def create_lib_data_path(name):
     return resource_filesystem_path(os.path.join(BASE_PATH_LIB_DATA, name))
 
 
-def create_ruleset_path(name, version=None):
+def create_ruleset_path(name, version=iati.version.STANDARD_VERSION_ANY):
     """Determine the path of a Ruleset with the given name at the specified version of the Standard.
 
     Args:
         name (str): The name of the Ruleset to locate.
-        version (str): The version of the Standard to return the Ruleset for. Defaults to None. This means that paths to a version-independent version of the Ruleset are returned.
+        version (str): The version of the Standard to return the Ruleset for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The path to a file containing the specified ruleset.
@@ -268,12 +268,12 @@ def create_ruleset_path(name, version=None):
     return path_for_version(os.path.join(PATH_RULESETS, '{0}'.format(name) + FILE_RULESET_EXTENSION), version)
 
 
-def create_schema_path(name, version=None):
+def create_schema_path(name, version=iati.version.STANDARD_VERSION_ANY):
     """Determine the path of a Schema with the given name at the specified version of the Standard.
 
     Args:
         name (str): The name of the Schema to locate.
-        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that paths to a version-independent version of the Schema is returned.
+        version (str): The version of the Standard to return the Schema for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The path to a file containing the specified Schema.
@@ -292,11 +292,11 @@ def create_schema_path(name, version=None):
 
 
 @iati.version.standardise_decimals
-def folder_name_for_version(version=None):
+def folder_name_for_version(version=iati.version.STANDARD_VERSION_ANY):
     """Return the folder name for a given version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the folder path for. Defaults to None. This means that the folder name independent of any version of the Standard is returned.
+        version (str): The version of the Standard to return the folder path for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The folder name for the specified version of the Standard.
@@ -308,7 +308,7 @@ def folder_name_for_version(version=None):
         Extract magic string: 'version-independent'
 
     """
-    if version is None:
+    if version == iati.version.STANDARD_VERSION_ANY:
         return 'version-independent'
     elif isinstance(version, str):
         try:
@@ -330,11 +330,11 @@ def folder_name_for_version(version=None):
     raise ValueError("Version {} is not a valid version of the IATI Standard.".format(version))
 
 
-def folder_path_for_version(version=None):
+def folder_path_for_version(version=iati.version.STANDARD_VERSION_ANY):
     """Return the path for the folder containing SSOT data (schemas, codelists etc) at the specified version of the Standard.
 
     Args:
-        version (str): The version of the Standard to return the folder path for. Defaults to None. This means that the path independent of any version of the Standard is returned.
+        version (str): The version of the Standard to return the folder path for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The relative path to the folder for containing SSOT data the specified version of the Standard.
@@ -343,12 +343,12 @@ def folder_path_for_version(version=None):
     return os.path.join(BASE_PATH_STANDARD, folder_name_for_version(version))
 
 
-def path_for_version(path, version=None):
+def path_for_version(path, version=iati.version.STANDARD_VERSION_ANY):
     """Return the relative location of a specified path at the specified version of the Standard.
 
     Args:
         path (str): The path to the file that is to be read in.
-        version (str): The version of the Standard to return the folder path for. Defaults to None. This means that the path independent of any version of the Standard is returned.
+        version (str): The version of the Standard to return the folder path for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The relative path to a file at the specified version of the Standard.

--- a/iati/tests/fixtures/versions.py
+++ b/iati/tests/fixtures/versions.py
@@ -243,7 +243,7 @@ def std_ver_minor_uninst_mixederr(request):
     return request.param
 
 
-@pytest.fixture(params=iati.tests.utilities.generate_test_types(['str', 'none', 'int'], True))
+@pytest.fixture(params=iati.tests.utilities.generate_test_types(['str', 'int'], True))
 def std_ver_all_uninst_typeerr(request):
     """Return a value of the wrong type to represent a version number.
 

--- a/iati/tests/resources.py
+++ b/iati/tests/resources.py
@@ -11,12 +11,12 @@ PATH_TEST_DATA = os.path.join(iati.resources.BASE_PATH, 'test_data')
 """The relative location of the folder containing IATI data files."""
 
 
-def get_test_data_path(name, version=None):
+def get_test_data_path(name, version=iati.version.STANDARD_VERSION_ANY):
     """Determine the path of an IATI data file with the given filename at the specified version of the Standard.
 
     Args:
         name (str): The name of the data file to locate. The name may contain forward slashes (`/`) to indicate a directory. Data files must be `.xml` files.
-        version (str): The version of the Standard to return the data files for. Defaults to None. This means that the path is returned for a filename independent of any version of the Standard.
+        version (str): The version of the Standard to return the data files for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The path to a file containing the specified data.
@@ -42,12 +42,12 @@ def get_test_data_path(name, version=None):
     return iati.resources.resource_filesystem_path(relative_path)
 
 
-def get_test_data_paths_in_folder(folder_name, version=None):
+def get_test_data_paths_in_folder(folder_name, version=iati.version.STANDARD_VERSION_ANY):
     """Determine the paths of all IATI data files in the specified folder under the root test folder.
 
     Args:
         name (str): The name of the folder within which to locate data files.
-        version (str): The version of the Standard to return the data files for. Defaults to None. This means that the path is returned for a filename independent of any version of the Standard.
+        version (str): The version of the Standard to return the data files for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         list of str: The paths to data files in the specified folders.
@@ -73,12 +73,12 @@ def get_test_data_paths_in_folder(folder_name, version=None):
     return deresourced_paths
 
 
-def get_test_ruleset_path(name, version=None):
+def get_test_ruleset_path(name, version=iati.version.STANDARD_VERSION_ANY):
     """Determine the path of an IATI test Ruleset file with the given filename at the specified version of the Standard.
 
     Args:
         name (str): The name of the data file to locate. The filename must not contain the '.xml' file extension.
-        version (str): The version of the Standard to return the data files for. Defaults to None. This means that the path is returned for a filename independent of any version of the Standard.
+        version (str): The version of the Standard to return the data files for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str: The path to a file containing the specified test Ruleset.
@@ -98,12 +98,12 @@ def get_test_ruleset_path(name, version=None):
     return os.path.join(PATH_TEST_DATA, iati.resources.folder_name_for_version(version), 'rulesets/{0}'.format(name) + iati.resources.FILE_RULESET_EXTENSION)
 
 
-def load_as_dataset(relative_path, version=None):
+def load_as_dataset(relative_path, version=iati.version.STANDARD_VERSION_ANY):
     """Load a specified test data file as a Dataset.
 
     Args:
         relative_path (str): The path of the file, relative to the root test data folder. Folders should be separated by a forward-slash (`/`).
-        version (str): The version of the Standard to return the data files for. Defaults to None. This means that the path is returned for a filename independent of any version of the Standard.
+        version (str): The version of the Standard to return the data files for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         dataset: A Dataset containing the contents of the file at the specified location.
@@ -117,12 +117,12 @@ def load_as_dataset(relative_path, version=None):
     return iati.utilities.load_as_dataset(path)
 
 
-def load_as_string(relative_path, version=None):
+def load_as_string(relative_path, version=iati.version.STANDARD_VERSION_ANY):
     """Load a specified test data file as a string.
 
     Args:
         relative_path (str): The path of the file, relative to the root test data folder. Folders should be separated by a forward-slash (`/`).
-        version (str): The version of the Standard to return the data files for. Defaults to None. This means that the path is returned for a filename independent of any version of the Standard.
+        version (str): The version of the Standard to return the data files for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
         str (python3) / unicode (python2): The contents of the file at the specified location.

--- a/iati/tests/test_resources.py
+++ b/iati/tests/test_resources.py
@@ -5,6 +5,7 @@ import pytest
 import iati.constants
 import iati.resources
 import iati.validator
+import iati.version
 
 
 class TestResources(object):
@@ -49,7 +50,7 @@ class TestResourceFolders(object):
         (iati.Version('1.01'), '1-01'),
         ('1', '1'),
         ('2', '2'),
-        (None, 'version-independent')
+        (iati.version.STANDARD_VERSION_ANY, 'version-independent')
     ])
     def test_folder_name_for_version(self, version, expected_version_foldername):
         """Check that expected components are present within folder paths."""

--- a/iati/tests/test_version.py
+++ b/iati/tests/test_version.py
@@ -325,6 +325,10 @@ class TestVersionConstants(object):
         """Check that the correct number of minor versions are detected."""
         assert len(iati.version.STANDARD_VERSIONS_MINOR) == 7
 
+    def test_standard_version_any_has_length(self):
+        """Check that the value to represent any version is a value with length."""
+        assert len(iati.version.STANDARD_VERSION_ANY)
+
 
 # pylint: disable=protected-access
 class VersionSupportChecksBase(object):
@@ -345,7 +349,7 @@ class VersionSupportChecksBase(object):
 
     @iati.version.allow_possible_version
     def return_possibly_version(version):  # pylint: disable=no-self-argument
-        """Return the version parameter, but only if it's known of by pyIATI. Check undertaken with decorator."""
+        """Return the version parameter, but only if it's a possible representation of a version number. Check undertaken with decorator."""
         return version
 
     @pytest.fixture(params=[return_fully_supported_version])
@@ -463,17 +467,11 @@ class TestVersionSupportChecks(VersionSupportChecksBase):
         assert version == original_value
         assert version is std_ver_major_uninst_valid_possible
 
-    def test_non_version_representation_valid_val_none(self, possibly_version_func):
-        """Test that None detected as being valid representations of an IATI Version Number.
+    def test_non_version_representation_valid_val_any(self, possibly_version_func):
+        """Test that the specified ANY_VERSION value detected as being valid representations of an IATI Version Number."""
+        version = possibly_version_func(iati.version.STANDARD_VERSION_ANY)
 
-        Todo:
-            Change magic value to be something other than `None`.
-            See: https://github.com/IATI/pyIATI/issues/218#issuecomment-364086162
-
-        """
-        version = possibly_version_func(None)
-
-        assert version is None
+        assert version == iati.version.STANDARD_VERSION_ANY
 
     def test_non_version_representation_invalid_val_integer(self, std_ver_major_uninst_valueerr, possibly_version_func):
         """Test that non-positive integers are detected as not being valid representations of an IATI Version Number."""

--- a/iati/version.py
+++ b/iati/version.py
@@ -229,6 +229,15 @@ STANDARD_VERSIONS_MINOR = STANDARD_VERSIONS
 """The minor versions of the IATI Standard."""
 
 
+STANDARD_VERSION_ANY = '*'
+"""A value to represent that something is applicable to all versions of the IATI Standard - it is version independent.
+
+Warning:
+    Assumptions should not be made as to the value of this constant other than it: `is not None`
+
+"""
+
+
 def allow_fully_supported_version(input_func):
     """Decorate function by ensuring versions are fully supported by pyIATI.
 
@@ -298,7 +307,7 @@ def allow_possible_version(input_func):
 
     In terms of value:
     * Permitted values representing an Integer or Decimal Version in a known format will remain unchanged.
-    * None will remain unchanged, as a way of representing all versions.
+    * STANDARD_VERSION_ANY will remain unchanged, as a way of representing all versions.
     * strings, integers and Decimals with values that cannot represent a Version will cause a ValueError.
     * Values of types other than string, Decimal, integer and iati.Version will cause a TypeError.
 
@@ -444,7 +453,7 @@ def _prevent_non_version_representations(version):
 
     In terms of value:
     * Permitted values representing an Integer or Decimal Version in a known format will remain unchanged.
-    * None will remain unchanged, as a way of representing all versions.
+    * STANDARD_VERSION_ANY will remain unchanged, as a way of representing all versions.
     * strings, integers and Decimals with values that cannot represent a Version will cause a ValueError.
     * Values of types other than string, Decimal, integer and iati.Version will cause a TypeError.
 
@@ -456,17 +465,17 @@ def _prevent_non_version_representations(version):
         ValueError: If a string, Decimal or integer has a value that is not in a format that is known to represent an IATI Version Number.
 
     """
-    if not isinstance(version, (str, Decimal, int, Version, type(None))) or isinstance(version, bool):
+    if not isinstance(version, (str, Decimal, int, Version)) or isinstance(version, bool):
         raise TypeError('IATI Version Numbers may only be represented as a string, Decimal, int or iati.Version. A {0} was provided.'.format(type(version)))
 
     try:
         Version(version)
     except ValueError:
-        if version == '0' or not version.isdigit():  # accept string representations of positive numbers
+        if version == '0' or (not version.isdigit() and version != STANDARD_VERSION_ANY):  # accept string representations of positive numbers
             raise ValueError('{0} is not a known representation of a potential IATI Version Number'.format(version))
     except TypeError:
         # will be an int or None or iati.Version if reaching this point
-        if version is not None and not isinstance(version, Version) and version < 1:
+        if not isinstance(version, Version) and version < 1:
             raise ValueError('IATI Integer Versions are all positive. {0} is a non-positive number.'.format(version))
 
     return version


### PR DESCRIPTION
This allows `==` to be used to check whether a value is this or not, rather than requiring use of `is`. By doing this, it gives more scope to change the value in the future.

A constant has been added to contain this value, and should be used if this meaning is required.

For original explanation for change, see: https://github.com/IATI/pyIATI/issues/218#issuecomment-364086162