### PR TITLE
More thoroughly test a version filtering decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [Constants] `STANDARD_VERSIONS_SUPPORTED` lists all versions of the Standard that are fully supported by pyIATI. [#223]
 - [Constants] `STANDARD_VERSIONS_MINOR` lists all Minor versions of the IATI Standard. [#264]
 
+- [Tests] Separate testing of `bytes` and `str` type values for Python 3+. [#286]
+
+### Changed
+
+- [Utilities] Raise a TypeError rather than a ValueError when `convert_xml_to_tree()` is given a value of incorrect type. [#286]
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- [Tests] Correct some very old test fixtures and documentation. [#286]
+
+### Security
+
+
+## [0.3.0] - 2018-02-16
+
+### Added
+
 - [Datasets] A Dataset `xml_tree` may be set with an ElementTree. [#235]
 
 - [Resources] Add ability to define resource files that are version-independent. [#223]

--- a/iati/data.py
+++ b/iati/data.py
@@ -86,14 +86,14 @@ class Dataset(object):
             try:
                 value_stripped = value.strip()
 
+                validation_error_log = iati.validator.validate_is_xml(value_stripped)
+
                 # Convert the input to bytes, as etree.fromstring works most consistently with bytes objects, especially if an XML encoding declaration has been used.
                 if (isinstance(value_stripped, str) and
                         sys.version_info.major > 2):  # Python v2 treats strings as byte objects by default
                     value_stripped_bytes = value_stripped.encode()
                 else:
                     value_stripped_bytes = value_stripped
-
-                validation_error_log = iati.validator.validate_is_xml(value_stripped_bytes)
 
                 if not validation_error_log.contains_errors():
                     self.xml_tree = etree.fromstring(value_stripped_bytes)

--- a/iati/tests/fixtures/versions.py
+++ b/iati/tests/fixtures/versions.py
@@ -275,7 +275,7 @@ def std_ver_minor_uninst_valid_iativer_possible(request):
 
 @pytest.fixture(params=MINOR_IATIVER_INVALID)
 def std_ver_minor_uninst_valueerr_iativer(request):
-    """Return a string that looks like it coule be a valid IATIver minor version number, but is not."""
+    """Return a string that looks like it could be a valid IATIver minor version number, but is not."""
     return request.param
 
 

--- a/iati/tests/test_data.py
+++ b/iati/tests/test_data.py
@@ -63,9 +63,9 @@ class TestDatasets(object):
 
         assert excinfo.value.error_log.contains_error_called('err-not-xml-empty-document')
 
-    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['str'], True))
-    def test_dataset_number_not_xml(self, not_xml):
-        """Test Dataset creation when it's passed a number rather than a string or etree."""
+    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
+    def test_dataset_not_xml(self, not_xml):
+        """Test Dataset creation when it's passed a type that is not a string or etree."""
         with pytest.raises(TypeError) as excinfo:
             iati.Dataset(not_xml)
 
@@ -120,13 +120,21 @@ class TestDatasets(object):
 
         assert str(excinfo.value) == 'If setting a Dataset with an ElementTree, use the xml_tree property, not the xml_str property.'
 
-    @pytest.mark.parametrize("invalid_value", iati.tests.utilities.generate_test_types(['str'], True))
+    @pytest.mark.parametrize("invalid_value", iati.tests.utilities.generate_test_types(['bytes', 'str']))
     def test_dataset_xml_str_assignment_invalid_value(self, dataset_initialised, invalid_value):
         """Test assignment to the xml_str property with a value that is very much not valid."""
         data = dataset_initialised
 
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises(ValueError):
             data.xml_str = invalid_value
+
+    @pytest.mark.parametrize("invalid_type", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
+    def test_dataset_xml_str_assignment_invalid_type(self, dataset_initialised, invalid_type):
+        """Test assignment to the xml_str property with a value that is very much not valid."""
+        data = dataset_initialised
+
+        with pytest.raises(TypeError) as excinfo:
+            data.xml_str = invalid_type
 
         assert 'Datasets can only be ElementTrees or strings containing valid XML, using the xml_tree and xml_str attributes respectively. Actual type:' in str(excinfo.value)
 

--- a/iati/tests/test_utilities.py
+++ b/iati/tests/test_utilities.py
@@ -169,19 +169,16 @@ class TestUtilities(object):
         assert tree.getchildren()[0].tag == 'child'
         assert not tree.getchildren()[0].getchildren()
 
-    def test_convert_xml_to_tree_invalid_str(self):
+    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['bytes', 'str']))
+    def test_convert_xml_to_tree_invalid_str(self, not_xml):
         """Check that an invalid string raises an error when an attempt is made to convert it to an etree."""
-        not_xml = "this is not XML"
-
-        with pytest.raises(etree.XMLSyntaxError) as excinfo:
+        with pytest.raises(etree.XMLSyntaxError):
             iati.utilities.convert_xml_to_tree(not_xml)
 
-        assert excinfo.typename == 'XMLSyntaxError'
-
-    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['str'], True))
+    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
     def test_convert_xml_to_tree_not_str(self, not_xml):
         """Check that an invalid string raises an error when an attempt is made to convert it to an etree."""
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(TypeError) as excinfo:
             iati.utilities.convert_xml_to_tree(not_xml)
 
         assert 'To parse XML into a tree, the XML must be a string, not a' in str(excinfo.value)

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -317,7 +317,7 @@ class TestValidationErrorLog(ValidationTestBase):  # pylint: disable=too-many-pu
 
         assert error_log == error_log_empty
 
-    @pytest.mark.parametrize("non_iterable", iati.tests.utilities.generate_test_types(['bytearray', 'iter', 'list', 'mapping', 'memory', 'range', 'set', 'str', 'tuple', 'view'], True))
+    @pytest.mark.parametrize("non_iterable", iati.tests.utilities.generate_test_types(['bytes', 'bytearray', 'iter', 'list', 'mapping', 'memory', 'range', 'set', 'str', 'tuple', 'view'], True))
     def test_error_log_extend_from_non_iterable(self, error_log, error_log_empty, non_iterable):
         """Test extending an error log with a non-iterable."""
         with pytest.raises(TypeError):
@@ -613,7 +613,18 @@ class TestValidateIsXML(ValidationTestBase):
 
         assert result == error_log_empty
 
-    @pytest.mark.parametrize("not_str", iati.tests.utilities.generate_test_types(['str'], True))
+    @pytest.mark.parametrize("bytes_not_xml", iati.tests.utilities.generate_test_types(['bytes']))
+    def test_xml_check_bytes_not_xml_detailed_output(self, bytes_not_xml):
+        """Perform check to see whether a parameter is valid XML. The parameter is a bytes object that is not valid XML.
+
+        Obtain detailed error output.
+        """
+        result = iati.validator.validate_is_xml(bytes_not_xml)
+
+        assert result.contains_errors()
+        assert result.contains_error_called('err-not-xml-empty-document')
+
+    @pytest.mark.parametrize("not_str", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
     def test_xml_check_not_str_detailed_output(self, not_str):
         """Perform check to see whether a parameter is valid XML. The parameter is not valid XML.
 

--- a/iati/tests/test_version.py
+++ b/iati/tests/test_version.py
@@ -480,10 +480,10 @@ class TestVersionSupportChecks(VersionSupportChecksBase):
         with pytest.raises(ValueError):
             possibly_version_func(std_ver_major_uninst_valueerr)
 
-    def test_non_version_representation_invalid_val(self, std_ver_minor_uninst_valueerr_iativer, possibly_version_func):
+    def test_non_version_representation_invalid_val(self, std_ver_minor_uninst_valueerr_str_decimal, possibly_version_func):
         """Test that values that are a correct type but cannot be a Decimal Version are detected as a ValueError."""
         with pytest.raises(ValueError):
-            possibly_version_func(std_ver_minor_uninst_valueerr_iativer)
+            possibly_version_func(std_ver_minor_uninst_valueerr_str_decimal)
 
     def test_non_version_representation_invalid_type(self, std_ver_all_uninst_typeerr, possibly_version_func):
         """Test that values of a type that cannot represent a Version cause a TypeError."""

--- a/iati/tests/utilities.py
+++ b/iati/tests/utilities.py
@@ -1,6 +1,8 @@
 """A module containing utility constants and functions for tests."""
 import decimal
+import sys
 import iati.constants
+import iati.resources
 import iati.tests.resources
 
 # This will need updating once test data forcing XML format is fixed
@@ -33,9 +35,12 @@ Todo:
 """
 
 
+_BYTES_VALS = [b'\x80abc', b'\x80abc']
+
+
 TYPE_TEST_DATA = {
     'bool': [True, False],
-    'bytes': [],  # counts as a string, so moved there
+    'bytes': [val for val in _BYTES_VALS if sys.version_info.major > 2],  # python2/3 compatibility
     'bytearray': [bytearray.fromhex('2Ef0 F1f2  '), bytearray(b'Hi!'), bytearray(range(20))],
     'complex': [3453J, -35415J, 0J, complex(234, 681), complex(-768, 16078), complex(6187, -81), complex(-1867, -618)],
     'contextmanager': [decimal.localcontext()],
@@ -50,7 +55,7 @@ TYPE_TEST_DATA = {
     'other': [NotImplemented],
     'range': [range(3, 4)],
     'set': [set(range(20)), set(['hello', 23]), frozenset(range(20)), frozenset(['hello', 23])],
-    'str': [b'\x80abc', b'\x80abc', '\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394', 'This is a string'],  # python2.7 warning # pylint: disable=anomalous-unicode-escape-in-string
+    'str': ['\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394', 'This is a string'] + [val for val in _BYTES_VALS if sys.version_info.major == 2],  # python2.7 warning # pylint: disable=anomalous-unicode-escape-in-string
     'tuple': [(), (1, 2)],
     'type': [type(1), type('string')],
     'unicode': [],  # counts as a string, so moved there

--- a/iati/utilities.py
+++ b/iati/utilities.py
@@ -111,7 +111,7 @@ def convert_xml_to_tree(xml):
     """Convert an XML string into an etree.
 
     Args:
-        xml (str): An XML string to be converted.
+        xml (str / bytes): An XML string to be converted.
 
     Returns:
         etree._Element: An lxml element tree representing the provided XML.
@@ -120,7 +120,7 @@ def convert_xml_to_tree(xml):
         Does not fully hide the lxml internal workings.
 
     Raises:
-        ValueError: The XML provided was something other than a string.
+        TypeError: The XML provided was something other than a string.
         lxml.etree.XMLSyntaxError: There was an error with the syntax of the provided XML.
 
     """
@@ -134,7 +134,7 @@ def convert_xml_to_tree(xml):
     except ValueError:
         msg = "To parse XML into a tree, the XML must be a string, not a {0}.".format(type(xml))
         iati.utilities.log_error(msg)
-        raise ValueError(msg)
+        raise TypeError(msg)
 
 
 def dict_raise_on_duplicates(ordered_pairs):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -467,7 +467,7 @@ def _check_is_xml(maybe_xml):
     """Check whether a given parameter is valid XML.
 
     Args:
-        maybe_xml (str): An string that may or may not contain valid XML.
+        maybe_xml (str / bytes): A string that may or may not contain valid XML.
 
     Returns:
         iati.validator.ValidationErrorLog: A log of the errors that occurred.

--- a/iati/version.py
+++ b/iati/version.py
@@ -483,8 +483,11 @@ def _prevent_non_version_representations(version):
     try:
         Version(version)
     except ValueError:
-        if version == '0' or not version.isdigit():  # accept string representations of positive numbers
-            raise ValueError('{0} is not a known representation of a potential IATI Version Number'.format(version))
+        try:
+            if version == '0' or not version.isdigit():  # accept string representations of positive numbers
+                raise ValueError('{0} is not a known representation of a potential IATI Version Number'.format(version))
+        except AttributeError:  # invalid decimal
+            raise ValueError('Only permitted versions at major version 1 may be represented using `decimal.Decimals` - {0} is not a permitted v1.0x version.'.format(version))
     except TypeError:
         # will be an int or None or iati.Version if reaching this point
         if version is not None and not isinstance(version, Version) and version < 1:


### PR DESCRIPTION
Invalid Decimal values were not previously tested when checking for permitted version numbers.

This modifies the test so that they are, and tweaks the code so that the updated test passes.