### PR TITLE
 Make visible an error message about unsupported values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
+- [Tests] Separate testing of `bytes` and `str` type values for Python 3+. [#286]
+
 ### Changed
+
+- [Utilities] Raise a TypeError rather than a ValueError when `convert_xml_to_tree()` is given a value of incorrect type. [#286]
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- [Tests] Correct some very old test fixtures and documentation. [#286]
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [Tests] Correct some very old test fixtures and documentation. [#286]
 
+- [Validation] Separate two similar but distinct ValueErrors that lxml may raise so that pyIATI treats them differently. [#287]
+
 ### Security
 
 

--- a/iati/data.py
+++ b/iati/data.py
@@ -86,14 +86,14 @@ class Dataset(object):
             try:
                 value_stripped = value.strip()
 
+                validation_error_log = iati.validator.validate_is_xml(value_stripped)
+
                 # Convert the input to bytes, as etree.fromstring works most consistently with bytes objects, especially if an XML encoding declaration has been used.
                 if (isinstance(value_stripped, str) and
                         sys.version_info.major > 2):  # Python v2 treats strings as byte objects by default
                     value_stripped_bytes = value_stripped.encode()
                 else:
                     value_stripped_bytes = value_stripped
-
-                validation_error_log = iati.validator.validate_is_xml(value_stripped_bytes)
 
                 if not validation_error_log.contains_errors():
                     self.xml_tree = etree.fromstring(value_stripped_bytes)

--- a/iati/resources/lib_data/validation_err_codes.yaml
+++ b/iati/resources/lib_data/validation_err_codes.yaml
@@ -219,7 +219,7 @@
     description: |-
         The tool used to parse XML does not support strings with encoding declarations.
     help: |-
-        pyIATI uses another tool to parse XML. This tool does not support Unicode strings with encoding delcarations.
+        pyIATI uses another tool to parse XML. This tool does not support Unicode strings with encoding declarations.
         To work around this, use bytes input or remove the specification of the encoding from the XML.
         For more information about encoding strings as bytes, see: https://docs.python.org/3/howto/unicode.html#converting-to-bytes
     info: |-

--- a/iati/resources/lib_data/validation_err_codes.yaml
+++ b/iati/resources/lib_data/validation_err_codes.yaml
@@ -213,6 +213,18 @@
     info: |-
         {err}
 
+- err-encoding-in-str:
+    base_exception: NotImplementedError
+    category: tool-lxml
+    description: |-
+        The tool used to parse XML does not support strings with encoding declarations.
+    help: |-
+        pyIATI uses another tool to parse XML. This tool does not support Unicode strings with encoding delcarations.
+        To work around this, use bytes input or remove the specification of the encoding from the XML.
+        For more information about encoding strings as bytes, see: https://docs.python.org/3/howto/unicode.html#converting-to-bytes
+    info: |-
+        {err}
+
 - err-encoding-invalid:
     base_exception: ValueError
     category: file

--- a/iati/tests/test_data.py
+++ b/iati/tests/test_data.py
@@ -211,8 +211,11 @@ class TestDatasetWithEncoding(object):
         BASE_XML_NEEDING_ENCODING + '\n',  # trailing newline
         BASE_XML_NEEDING_ENCODING + ' '  # trailing space
     ])
-    def xml_needing_encoding_leading_whitespace(self, request):
-        """An XML string with a placeholder for an encoding through use of `str.format()`"""
+    def xml_needing_encoding_use_as_str(self, request):
+        """An XML string with a placeholder for an encoding through use of `str.format()`.
+
+        Some values work when used as a `str`, but not as `bytes`.
+        """
         return request.param
 
     def test_instantiation_dataset_from_string(self):
@@ -229,9 +232,9 @@ class TestDatasetWithEncoding(object):
         assert isinstance(dataset, iati.data.Dataset)
         assert dataset.xml_str == xml_str
 
-    def test_instantiation_dataset_from_string_with_encoding(self, xml_needing_encoding_leading_whitespace):
+    def test_instantiation_dataset_from_string_with_encoding(self, xml_needing_encoding_use_as_str):
         """Test that an encoded Dataset instantiated directly from a string (rather than a file or bytes object) correctly creates an iati.data.Dataset and the input data is contained within the object."""
-        xml = xml_needing_encoding_leading_whitespace.format('UTF-8')
+        xml = xml_needing_encoding_use_as_str.format('UTF-8')
 
         if sys.version_info.major > 2:
             with pytest.raises(iati.exceptions.ValidationError) as validation_err:

--- a/iati/tests/test_data.py
+++ b/iati/tests/test_data.py
@@ -5,6 +5,7 @@ Todo:
 """
 import collections
 import math
+import sys
 from future.standard_library import install_aliases
 from lxml import etree
 import pytest
@@ -232,11 +233,17 @@ class TestDatasetWithEncoding(object):
         """Test that an encoded Dataset instantiated directly from a string (rather than a file or bytes object) correctly creates an iati.data.Dataset and the input data is contained within the object."""
         xml = xml_needing_encoding_leading_whitespace.format('UTF-8')
 
-        with pytest.raises(iati.exceptions.ValidationError) as validation_err:
-            iati.data.Dataset(xml)
+        if sys.version_info.major > 2:
+            with pytest.raises(iati.exceptions.ValidationError) as validation_err:
+                iati.data.Dataset(xml)
 
-        assert len(validation_err.value.error_log) == 1
-        assert validation_err.value.error_log.contains_error_called('err-encoding-in-str')
+            assert len(validation_err.value.error_log) == 1
+            assert validation_err.value.error_log.contains_error_called('err-encoding-in-str')
+        else:
+            dataset = iati.data.Dataset(xml)
+
+            assert isinstance(dataset, iati.data.Dataset)
+            assert dataset.xml_str == xml.strip()
 
     @pytest.mark.parametrize("encoding", [
         "UTF-8",

--- a/iati/tests/test_data.py
+++ b/iati/tests/test_data.py
@@ -187,17 +187,32 @@ class TestDatasetWithEncoding(object):
 
     """
 
-    @pytest.fixture
-    def xml_needing_encoding(self):
-        """An XML string with a placeholder for an encoding through use of `str.format()`"""
-        xml = """<?xml version="1.0" encoding="{}"?>
+    BASE_XML_NEEDING_ENCODING = """<?xml version="1.0" encoding="{}"?>
         <iati-activities version="xx">
           <iati-activity>
              <iati-identifier></iati-identifier>
          </iati-activity>
         </iati-activities>"""
 
-        return xml
+    @pytest.fixture(params=[
+        BASE_XML_NEEDING_ENCODING,
+        BASE_XML_NEEDING_ENCODING + '\n',  # trailing newline
+        BASE_XML_NEEDING_ENCODING + ' '  # trailing space
+    ])
+    def xml_needing_encoding(self, request):
+        """An XML string with a placeholder for an encoding through use of `str.format()`"""
+        return request.param
+
+    @pytest.fixture(params=[
+        BASE_XML_NEEDING_ENCODING,
+        '\n' + BASE_XML_NEEDING_ENCODING,  # leading newline
+        ' ' + BASE_XML_NEEDING_ENCODING,  # leading space
+        BASE_XML_NEEDING_ENCODING + '\n',  # trailing newline
+        BASE_XML_NEEDING_ENCODING + ' '  # trailing space
+    ])
+    def xml_needing_encoding_leading_whitespace(self, request):
+        """An XML string with a placeholder for an encoding through use of `str.format()`"""
+        return request.param
 
     def test_instantiation_dataset_from_string(self):
         """Test that a Dataset instantiated directly from a string (rather than a file) correctly creates an iati.data.Dataset and the input data is contained within the object."""
@@ -213,6 +228,16 @@ class TestDatasetWithEncoding(object):
         assert isinstance(dataset, iati.data.Dataset)
         assert dataset.xml_str == xml_str
 
+    def test_instantiation_dataset_from_string_with_encoding(self, xml_needing_encoding_leading_whitespace):
+        """Test that an encoded Dataset instantiated directly from a string (rather than a file or bytes object) correctly creates an iati.data.Dataset and the input data is contained within the object."""
+        xml = xml_needing_encoding_leading_whitespace.format('UTF-8')
+
+        with pytest.raises(iati.exceptions.ValidationError) as validation_err:
+            iati.data.Dataset(xml)
+
+        assert len(validation_err.value.error_log) == 1
+        assert validation_err.value.error_log.contains_error_called('err-encoding-in-str')
+
     @pytest.mark.parametrize("encoding", [
         "UTF-8",
         "utf-8",
@@ -226,8 +251,8 @@ class TestDatasetWithEncoding(object):
         "BIG5",
         "EUC-JP"
     ])
-    def test_instantiation_dataset_from_string_with_encoding(self, xml_needing_encoding, encoding):
-        """Test that an encoded Dataset instantiated directly from a string (rather than a file) correctly creates an iati.data.Dataset and the input data is contained within the object.
+    def test_instantiation_dataset_from_encoded_string_with_encoding(self, xml_needing_encoding, encoding):
+        """Test that an encoded Dataset instantiated directly from an encoded string (rather than a file) correctly creates an iati.data.Dataset and the input data is contained within the object.
 
         Note:
             The use of UTF-8 and UTF-16 is strongly recommended for IATI datasets, however other encodings are specificed here to demonstrate compatibility.
@@ -239,7 +264,7 @@ class TestDatasetWithEncoding(object):
         dataset = iati.data.Dataset(xml_encoded)
 
         assert isinstance(dataset, iati.data.Dataset)
-        assert dataset.xml_str == xml_encoded
+        assert dataset.xml_str == xml_encoded.strip()
 
     @pytest.mark.parametrize("encoding_declared, encoding_used", [
         ("UTF-16", "UTF-8"),
@@ -248,8 +273,8 @@ class TestDatasetWithEncoding(object):
         ("UTF-16", "BIG5"),
         ("UTF-16", "EUC-JP")
     ])
-    def test_instantiation_dataset_from_string_with_encoding_mismatch(self, xml_needing_encoding, encoding_declared, encoding_used):
-        """Test that an error is raised when attempting to create a Dataset where a string is encoded significantly differently from what is defined within the XML encoding declaration.
+    def test_instantiation_dataset_from_encoded_string_with_encoding_mismatch(self, xml_needing_encoding, encoding_declared, encoding_used):
+        """Test that an error is raised when attempting to create a Dataset where an encoded string is encoded significantly differently from what is defined within the XML encoding declaration.
 
         Todo:
             Amend error message, when the todo in iati.data.Dataset.xml_str() has been resolved.
@@ -272,8 +297,8 @@ class TestDatasetWithEncoding(object):
         assert excinfo.value.error_log.contains_error_called('err-encoding-invalid')
 
     @pytest.mark.parametrize("encoding", ["CP424"])
-    def test_instantiation_dataset_from_string_with_unsupported_encoding(self, xml_needing_encoding, encoding):
-        """Test that an error is raised when attempting to create a dataset where a string is encoded significantly differently from what is defined within the XML encoding declaration.
+    def test_instantiation_dataset_from_encoded_string_with_unsupported_encoding(self, xml_needing_encoding, encoding):
+        """Test that an error is raised when attempting to create a dataset where an encoded string is encoded significantly differently from what is defined within the XML encoding declaration.
 
         Todo:
             Amend error message, when the todo in iati.data.Dataset.xml_str() has been resolved.

--- a/iati/tests/test_data.py
+++ b/iati/tests/test_data.py
@@ -63,9 +63,9 @@ class TestDatasets(object):
 
         assert excinfo.value.error_log.contains_error_called('err-not-xml-empty-document')
 
-    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['str'], True))
-    def test_dataset_number_not_xml(self, not_xml):
-        """Test Dataset creation when it's passed a number rather than a string or etree."""
+    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
+    def test_dataset_not_xml(self, not_xml):
+        """Test Dataset creation when it's passed a type that is not a string or etree."""
         with pytest.raises(TypeError) as excinfo:
             iati.Dataset(not_xml)
 
@@ -120,13 +120,21 @@ class TestDatasets(object):
 
         assert str(excinfo.value) == 'If setting a Dataset with an ElementTree, use the xml_tree property, not the xml_str property.'
 
-    @pytest.mark.parametrize("invalid_value", iati.tests.utilities.generate_test_types(['str'], True))
+    @pytest.mark.parametrize("invalid_value", iati.tests.utilities.generate_test_types(['bytes', 'str']))
     def test_dataset_xml_str_assignment_invalid_value(self, dataset_initialised, invalid_value):
         """Test assignment to the xml_str property with a value that is very much not valid."""
         data = dataset_initialised
 
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises(ValueError):
             data.xml_str = invalid_value
+
+    @pytest.mark.parametrize("invalid_type", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
+    def test_dataset_xml_str_assignment_invalid_type(self, dataset_initialised, invalid_type):
+        """Test assignment to the xml_str property with a value that is very much not valid."""
+        data = dataset_initialised
+
+        with pytest.raises(TypeError) as excinfo:
+            data.xml_str = invalid_type
 
         assert 'Datasets can only be ElementTrees or strings containing valid XML, using the xml_tree and xml_str attributes respectively. Actual type:' in str(excinfo.value)
 

--- a/iati/tests/test_utilities.py
+++ b/iati/tests/test_utilities.py
@@ -160,19 +160,16 @@ class TestUtilities(object):
         assert tree.getchildren()[0].tag == 'child'
         assert not tree.getchildren()[0].getchildren()
 
-    def test_convert_xml_to_tree_invalid_str(self):
+    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['bytes', 'str']))
+    def test_convert_xml_to_tree_invalid_str(self, not_xml):
         """Check that an invalid string raises an error when an attempt is made to convert it to an etree."""
-        not_xml = "this is not XML"
-
-        with pytest.raises(etree.XMLSyntaxError) as excinfo:
+        with pytest.raises(etree.XMLSyntaxError):
             iati.utilities.convert_xml_to_tree(not_xml)
 
-        assert excinfo.typename == 'XMLSyntaxError'
-
-    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['str'], True))
+    @pytest.mark.parametrize("not_xml", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
     def test_convert_xml_to_tree_not_str(self, not_xml):
         """Check that an invalid string raises an error when an attempt is made to convert it to an etree."""
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(TypeError) as excinfo:
             iati.utilities.convert_xml_to_tree(not_xml)
 
         assert 'To parse XML into a tree, the XML must be a string, not a' in str(excinfo.value)

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -1,5 +1,6 @@
 """A module containing tests for data validation."""
 # pylint: disable=too-many-lines
+import sys
 import pytest
 import iati.data
 import iati.default
@@ -529,7 +530,11 @@ class TestValidateIsXML(ValidationTestBase):
         """
         result = iati.validator.validate_is_xml(xml_str_explicit_encoding)
 
-        assert result.contains_error_called('err-encoding-in-str')
+        if sys.version_info.major > 2:
+            assert len(result) == 1
+            assert result.contains_error_called('err-encoding-in-str')
+        else:
+            assert not len(result)
 
     def test_xml_check_valid_xml_comments_after_detailed_output(self, xml_str, str_not_xml, error_log_empty):
         """Perform check to see string a parameter is valid XML.

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -297,7 +297,7 @@ class TestValidationErrorLog(ValidationTestBase):  # pylint: disable=too-many-pu
 
         assert error_log == error_log_empty
 
-    @pytest.mark.parametrize("non_iterable", iati.tests.utilities.generate_test_types(['bytearray', 'iter', 'list', 'mapping', 'memory', 'range', 'set', 'str', 'tuple', 'view'], True))
+    @pytest.mark.parametrize("non_iterable", iati.tests.utilities.generate_test_types(['bytes', 'bytearray', 'iter', 'list', 'mapping', 'memory', 'range', 'set', 'str', 'tuple', 'view'], True))
     def test_error_log_extend_from_non_iterable(self, error_log, error_log_empty, non_iterable):
         """Test extending an error log with a non-iterable."""
         with pytest.raises(TypeError):
@@ -543,7 +543,18 @@ class TestValidateIsXML(ValidationTestBase):
 
         assert result == error_log_empty
 
-    @pytest.mark.parametrize("not_str", iati.tests.utilities.generate_test_types(['str'], True))
+    @pytest.mark.parametrize("bytes_not_xml", iati.tests.utilities.generate_test_types(['bytes']))
+    def test_xml_check_bytes_not_xml_detailed_output(self, bytes_not_xml):
+        """Perform check to see whether a parameter is valid XML. The parameter is a bytes object that is not valid XML.
+
+        Obtain detailed error output.
+        """
+        result = iati.validator.validate_is_xml(bytes_not_xml)
+
+        assert result.contains_errors()
+        assert result.contains_error_called('err-not-xml-empty-document')
+
+    @pytest.mark.parametrize("not_str", iati.tests.utilities.generate_test_types(['bytes', 'str'], True))
     def test_xml_check_not_str_detailed_output(self, not_str):
         """Perform check to see whether a parameter is valid XML. The parameter is not valid XML.
 

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -42,6 +42,23 @@ class ValidationTestBase(object):
         return request.param
 
     @pytest.fixture
+    def xml_str_explicit_encoding(self, request):
+        """A valid XML string with an explicit encoding declaration.
+
+        Todo:
+            Move this into a file as part of a shuffle towards a permanent 2.03 solution.
+
+        """
+        xml_str_explicit_encoding = """<?xml version="1.0" encoding="UTF-8"?>
+        <iati-activities version="xx">
+          <iati-activity>
+             <iati-identifier></iati-identifier>
+         </iati-activity>
+        </iati-activities>"""
+
+        return xml_str_explicit_encoding
+
+    @pytest.fixture
     def xml_str_no_text_decl(self, xml_str):
         """A valid XML string with the text declaration removed."""
         return '\n'.join(xml_str.strip().split('\n')[1:])
@@ -503,6 +520,16 @@ class TestValidateIsXML(ValidationTestBase):
         result = iati.validator.validate_is_xml(xml_str)
 
         assert result == error_log_empty
+
+    def test_xml_check_explicit_encoding_in_str_detailed_output(self, xml_str_explicit_encoding):
+        """Perform check to see whether a parameter is valid XML.
+
+        The parameter is valid XML, but in a format that lxml does not support.
+        Obtain detailed error output.
+        """
+        result = iati.validator.validate_is_xml(xml_str_explicit_encoding)
+
+        assert result.contains_error_called('err-encoding-in-str')
 
     def test_xml_check_valid_xml_comments_after_detailed_output(self, xml_str, str_not_xml, error_log_empty):
         """Perform check to see string a parameter is valid XML.

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -43,7 +43,7 @@ class ValidationTestBase(object):
         return request.param
 
     @pytest.fixture
-    def xml_str_explicit_encoding(self, request):
+    def xml_str_explicit_encoding(self):
         """A valid XML string with an explicit encoding declaration.
 
         Todo:
@@ -51,11 +51,8 @@ class ValidationTestBase(object):
 
         """
         xml_str_explicit_encoding = """<?xml version="1.0" encoding="UTF-8"?>
-        <iati-activities version="xx">
-          <iati-activity>
-             <iati-identifier></iati-identifier>
-         </iati-activity>
-        </iati-activities>"""
+        <xml-element>
+        </xml-element>"""
 
         return xml_str_explicit_encoding
 
@@ -522,7 +519,7 @@ class TestValidateIsXML(ValidationTestBase):
 
         assert result == error_log_empty
 
-    def test_xml_check_explicit_encoding_in_str_detailed_output(self, xml_str_explicit_encoding):
+    def test_xml_check_explicit_encoding_in_str_detailed_output(self, xml_str_explicit_encoding, error_log_empty):
         """Perform check to see whether a parameter is valid XML.
 
         The parameter is valid XML, but in a format that lxml does not support.
@@ -534,7 +531,7 @@ class TestValidateIsXML(ValidationTestBase):
             assert len(result) == 1
             assert result.contains_error_called('err-encoding-in-str')
         else:
-            assert not len(result)
+            assert result == error_log_empty
 
     def test_xml_check_valid_xml_comments_after_detailed_output(self, xml_str, str_not_xml, error_log_empty):
         """Perform check to see string a parameter is valid XML.

--- a/iati/tests/utilities.py
+++ b/iati/tests/utilities.py
@@ -1,7 +1,8 @@
 """A module containing utility constants and functions for tests."""
 import decimal
-import iati.resources
+import sys
 import iati.constants
+import iati.resources
 import iati.tests.resources
 
 
@@ -25,9 +26,12 @@ XML_TREE_VALID_IATI_INVALID_CODE = iati.utilities.load_as_tree(iati.tests.resour
 """A valid IATI etree that has an invalid Code value."""
 
 
+_BYTES_VALS = [b'\x80abc', b'\x80abc']
+
+
 TYPE_TEST_DATA = {
     'bool': [True, False],
-    'bytes': [],  # counts as a string, so moved there
+    'bytes': [val for val in _BYTES_VALS if sys.version_info.major > 2],  # python2/3 compatibility
     'bytearray': [bytearray.fromhex('2Ef0 F1f2  '), bytearray(b'Hi!'), bytearray(range(20))],
     'complex': [3453J, -35415J, 0J, complex(234, 681), complex(-768, 16078), complex(6187, -81), complex(-1867, -618)],
     'contextmanager': [decimal.localcontext()],
@@ -42,7 +46,7 @@ TYPE_TEST_DATA = {
     'other': [NotImplemented],
     'range': [range(3, 4)],
     'set': [set(range(20)), set(['hello', 23]), frozenset(range(20)), frozenset(['hello', 23])],
-    'str': [b'\x80abc', b'\x80abc', '\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394', 'This is a string'],  # python2.7 warning # pylint: disable=anomalous-unicode-escape-in-string
+    'str': ['\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394', 'This is a string'] + [val for val in _BYTES_VALS if sys.version_info.major == 2],  # python2.7 warning # pylint: disable=anomalous-unicode-escape-in-string
     'tuple': [(), (1, 2)],
     'type': [type(1), type('string')],
     'unicode': [],  # counts as a string, so moved there

--- a/iati/utilities.py
+++ b/iati/utilities.py
@@ -111,7 +111,7 @@ def convert_xml_to_tree(xml):
     """Convert an XML string into an etree.
 
     Args:
-        xml (str): An XML string to be converted.
+        xml (str / bytes): An XML string to be converted.
 
     Returns:
         etree._Element: An lxml element tree representing the provided XML.
@@ -120,7 +120,7 @@ def convert_xml_to_tree(xml):
         Does not fully hide the lxml internal workings.
 
     Raises:
-        ValueError: The XML provided was something other than a string.
+        TypeError: The XML provided was something other than a string.
         lxml.etree.XMLSyntaxError: There was an error with the syntax of the provided XML.
 
     """
@@ -134,7 +134,7 @@ def convert_xml_to_tree(xml):
     except ValueError:
         msg = "To parse XML into a tree, the XML must be a string, not a {0}.".format(type(xml))
         iati.utilities.log_error(msg)
-        raise ValueError(msg)
+        raise TypeError(msg)
 
 
 def dict_raise_on_duplicates(ordered_pairs):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -477,7 +477,16 @@ def _check_is_xml(maybe_xml):
         for log_entry in parser.error_log:
             error = _create_error_for_lxml_log_entry(log_entry)
             error_log.add(error)
-    except (AttributeError, TypeError, ValueError):
+        # test_xml_check_not_xml, test_xml_check_not_str_detailed_output
+    except ValueError as err:
+        if 'can only parse strings' in err.args[0]:
+            problem_var_type = type(maybe_xml)  # used via `locals()` # pylint: disable=unused-variable
+            error = ValidationError('err-not-xml-not-string', locals())
+            error_log.add(error)
+        elif 'Unicode strings with encoding declaration are not supported.' in err.args[0]:
+            error = ValidationError('err-encoding-in-str', locals())
+            error_log.add(error)
+    except (AttributeError, TypeError):
         problem_var_type = type(maybe_xml)  # used via `locals()` # pylint: disable=unused-variable
         error = ValidationError('err-not-xml-not-string', locals())
         error_log.add(error)

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -456,7 +456,7 @@ def _check_is_xml(maybe_xml):
     """Check whether a given parameter is valid XML.
 
     Args:
-        maybe_xml (str): An string that may or may not contain valid XML.
+        maybe_xml (str / bytes): A string that may or may not contain valid XML.
 
     Returns:
         iati.validator.ValidationErrorLog: A log of the errors that occurred.


### PR DESCRIPTION
#286 should be merged first

lxml does not support strings with an encoding declaration. They must be bytes objects if there is an encoding declaration. Previously, this error was grouped in with others. This separates two possible ValueErrors that lxml may raise so that it's clearer.

This issue was highlighted in #285