### PR TITLE
Change TODOs about fixed versions to marks

### DIFF
--- a/iati/tests/conftest.py
+++ b/iati/tests/conftest.py
@@ -30,16 +30,15 @@ def codelist_lengths_by_version(request):
 
 
 @pytest.fixture
-def schema_ruleset():
+def schema_ruleset(request):
     """Return a schema with the Standard Ruleset added.
 
     Returns:
         A valid Activity Schema with the Standard Ruleset added.
 
-    Todo:
-        Stop this being fixed to 2.02.
-
     """
+    request.applymarker(pytest.mark.fixed_to_202)
+
     schema = iati.default.activity_schema('2.02', False)
     ruleset = iati.default.ruleset('2.02')
 

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -62,13 +62,9 @@ class TestCodelists(object):
 
         assert num_codes == 0
 
+    @pytest.mark.fixed_to_202
     def test_codelist_define_from_xml(self, name_to_set):
-        """Check that a Codelist can be generated from an XML codelist definition.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Codelist can be generated from an XML codelist definition."""
         path = iati.resources.create_codelist_path('FlowType', '2.02')
         xml_str = iati.utilities.load_as_string(path)
         codelist = iati.Codelist(name_to_set, xml=xml_str)
@@ -82,13 +78,9 @@ class TestCodelists(object):
             assert code.name in code_names
             assert code.value in code_values
 
+    @pytest.mark.fixed_to_202
     def test_codelist_complete(self):
-        """Check that a Codelist can be generated from an XML codelist definition.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Codelist can be generated from an XML codelist definition."""
         codelist_name = 'BudgetType'
         path = iati.resources.create_codelist_path(codelist_name, '2.02')
         xml_str = iati.utilities.load_as_string(path)
@@ -97,13 +89,9 @@ class TestCodelists(object):
 
         assert codelist.complete is True
 
+    @pytest.mark.fixed_to_202
     def test_codelist_incomplete(self):
-        """Check that a Codelist can be generated from an XML codelist definition.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Codelist can be generated from an XML codelist definition."""
         codelist_name = 'Country'
         path = iati.resources.create_codelist_path(codelist_name, '2.02')
         xml_str = iati.utilities.load_as_string(path)

--- a/iati/tests/test_data.py
+++ b/iati/tests/test_data.py
@@ -296,12 +296,9 @@ class TestDatasetSourceFinding(object):
         iati.tests.resources.load_as_dataset('valid_iati', '2.02')
     ])
     def data(self, request):
-        """A Dataset to test.
+        """A Dataset to test."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         return request.param
 
     @pytest.fixture
@@ -578,13 +575,9 @@ class TestDatasetVersionDetection(object):
 
         assert result == std_ver_minor_inst_valid_known_v2
 
+    @pytest.mark.fixed_to_202
     def test_cannot_assign_to_version_property(self):
-        """Check that it is not possible to assign to the `version` property.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that it is not possible to assign to the `version` property."""
         data = iati.tests.resources.load_as_dataset('valid_iati', '2.02')
 
         with pytest.raises(AttributeError) as excinfo:

--- a/iati/tests/test_default.py
+++ b/iati/tests/test_default.py
@@ -142,14 +142,12 @@ class TestDefaultCodelists(object):
             for code in codelist.codes:
                 assert code.name == ''
 
+    @pytest.mark.fixed_to_202
     def test_codelist_mapping_condition(self):
         """Check that the Codelist mapping file is having conditions read.
 
         Todo:
             Split into multiple tests.
-
-            Stop this being fixed to 2.02.
-
         """
         mapping = iati.default.codelist_mapping('2.02')
 
@@ -204,13 +202,9 @@ class TestDefaultRulesets(object):
 
         assert isinstance(ruleset, iati.Ruleset)
 
+    @pytest.mark.fixed_to_202
     def test_default_ruleset_validation_rules_valid(self, schema_ruleset):
-        """Check that a fully valid IATI file does not raise any type of error (including rules/rulesets).
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a fully valid IATI file does not raise any type of error (including rules/rulesets)."""
         data = iati.tests.resources.load_as_dataset('valid_std_ruleset', '2.02')
         result = iati.validator.full_validation(data, schema_ruleset)
 
@@ -241,6 +235,7 @@ class TestDefaultRulesets(object):
         )
         # Note the Rules relating to 'dependent', 'no_more_than_one', 'regex_no_matches', 'startswith' and 'unique' are not used in the Standard Ruleset.
     ])
+    @pytest.mark.fixed_to_202
     def test_default_ruleset_validation_rules_invalid(self, schema_ruleset, rule_error, invalid_dataset_name, info_text):
         """Check that the expected rule error is detected when validating files containing invalid data for that rule.
 
@@ -252,9 +247,6 @@ class TestDefaultRulesets(object):
             Consider whether this test should remove all warnings and assert that there is only the expected warning contained within the test file.
 
             Check that the expected missing elements appear the the help text for the given element.
-
-            Stop this being fixed to 2.02.
-
         """
         data = iati.tests.resources.load_as_dataset(invalid_dataset_name, '2.02')
         result = iati.validator.full_validation(data, schema_ruleset)
@@ -327,13 +319,10 @@ class TestDefaultModifications(object):
         return 'Country'
 
     @pytest.fixture
-    def codelist(self, codelist_name):
-        """Return a default Codelist that is part of the IATI Standard.
+    def codelist(self, request, codelist_name):
+        """Return a default Codelist that is part of the IATI Standard."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         return iati.default.codelist(codelist_name, '2.02')
 
     @pytest.fixture

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -164,13 +164,9 @@ class TestRulesetInitialisation(RulesetFixtures):
 class TestRulesetValidityChecks(RulesetFixtures):
     """A container for tests relating to checking whether a Dataset is valid for a Ruleset."""
 
+    @pytest.mark.fixed_to_202
     def test_ruleset_is_valid_for_valid_dataset(self):
-        """Check that a Dataset can be validated against the Standard Ruleset.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Dataset can be validated against the Standard Ruleset."""
         ruleset = iati.tests.utilities.RULESET_FOR_TESTING
         valid_dataset = iati.tests.resources.load_as_dataset('valid_std_ruleset', '2.02')
 
@@ -182,13 +178,9 @@ class TestRulesetValidityChecks(RulesetFixtures):
         iati.tests.resources.load_as_dataset('ruleset-std/invalid_std_ruleset_does_not_sum_100', '2.02'),
         iati.tests.resources.load_as_dataset('ruleset-std/invalid_std_ruleset_missing_sector_element', '2.02')
     ])
+    @pytest.mark.fixed_to_202
     def test_ruleset_is_invalid_for_invalid_dataset(self, invalid_dataset):
-        """Check that a Dataset can be invalidated against the Standard Ruleset.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Dataset can be invalidated against the Standard Ruleset."""
         ruleset = iati.tests.utilities.RULESET_FOR_TESTING
         assert not ruleset.is_valid_for(invalid_dataset)
 

--- a/iati/tests/test_schemas.py
+++ b/iati/tests/test_schemas.py
@@ -206,14 +206,12 @@ class TestSchemas(SchemaTestsBase):
 
         assert len(schema_initialised.codelists) == 1
 
+    @pytest.mark.fixed_to_202
     def test_schema_rulesets_add(self, schema_initialised):
         """Check that it is possible to add Rulesets to the Schema.
 
         Todo:
             Consider if this test should test against a versioned Ruleset.
-
-            Stop this being fixed to 2.02.
-
         """
         ruleset = iati.default.ruleset('2.02')
 
@@ -221,14 +219,12 @@ class TestSchemas(SchemaTestsBase):
 
         assert len(schema_initialised.rulesets) == 1
 
+    @pytest.mark.fixed_to_202
     def test_schema_rulesets_add_twice(self, schema_initialised):
         """Check that it is not possible to add the same Ruleset to a Schema multiple times.
 
         Todo:
             Consider if this test should test against a versioned Ruleset.
-
-            Stop this being fixed to 2.02.
-
         """
         ruleset = iati.default.ruleset('2.02')
 
@@ -237,14 +233,12 @@ class TestSchemas(SchemaTestsBase):
 
         assert len(schema_initialised.rulesets) == 1
 
+    @pytest.mark.fixed_to_202
     def test_schema_rulesets_add_duplicate(self, schema_initialised):
         """Check that it is possible to add multiple functionally identical Rulesets to a Schema.
 
         Todo:
             Consider if this test should test against a versioned Ruleset.
-
-            Stop this being fixed to 2.02.
-
         """
         ruleset = iati.default.ruleset('2.02')
         ruleset_copy = copy.deepcopy(ruleset)
@@ -254,14 +248,12 @@ class TestSchemas(SchemaTestsBase):
 
         assert len(schema_initialised.rulesets) == 2
 
+    @pytest.mark.fixed_to_202
     def test_schema_rulesets_add_two_different(self, schema_initialised):
         """Check that it is possible to add multiple different Rulesets to a Schema.
 
         Todo:
             Consider if this test should test against a versioned Ruleset.
-
-            Stop this being fixed to 2.02.
-
         """
         ruleset = iati.default.ruleset('2.02')
         ruleset_copy = copy.deepcopy(ruleset)

--- a/iati/tests/test_utilities.py
+++ b/iati/tests/test_utilities.py
@@ -11,13 +11,10 @@ class TestUtilities(object):
     """A container for tests relating to utilities."""
 
     @pytest.fixture
-    def schema_base_tree(self):
-        """Return schema_base_tree.
+    def schema_base_tree(self, request):
+        """Return schema_base_tree."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         activity_schema_path = iati.resources.get_activity_schema_paths('2.02')[0]
 
         return iati.ActivitySchema(activity_schema_path)._schema_base_tree  # pylint: disable=protected-access
@@ -141,13 +138,9 @@ class TestUtilities(object):
 
         assert 'The `new_ns_uri` parameter must be a valid URI.' in str(excinfo.value)
 
+    @pytest.mark.fixed_to_202
     def test_convert_tree_to_schema(self):
-        """Check that an etree can be converted to a schema.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that an etree can be converted to a schema."""
         path = iati.resources.get_activity_schema_paths('2.02')[0]
 
         tree = iati.utilities.load_as_tree(path)

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -12,13 +12,10 @@ class ValidationTestBase(object):
     """A container for fixtures and other functionality useful among multiple groups of Validation Test."""
 
     @pytest.fixture
-    def schema_basic(self):
-        """An Activity Schema with no Codelists added.
+    def schema_basic(self, request):
+        """An Activity Schema with no Codelists added."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         return iati.default.activity_schema('2.02', False)
 
     @pytest.fixture
@@ -27,13 +24,10 @@ class ValidationTestBase(object):
         return iati.default.organisation_schema(None, False)
 
     @pytest.fixture
-    def schema_fully_populated(self):
-        """Return an Activity Schema populated with all Codelists.
+    def schema_fully_populated(self, request):
+        """Return an Activity Schema populated with all Codelists."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02 (see: #223).
-
-        """
         return iati.default.activity_schema('2.02')
 
     @pytest.fixture(params=[
@@ -43,12 +37,9 @@ class ValidationTestBase(object):
         iati.tests.resources.load_as_string('leading_whitespace_xml')
     ])
     def xml_str(self, request):
-        """A valid XML string.
+        """A valid XML string."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         return request.param
 
     @pytest.fixture
@@ -80,12 +71,9 @@ class ValidationTestBase(object):
         iati.tests.resources.load_as_dataset('valid_iati_invalid_code', '2.02')
     ])
     def iati_dataset(self, request):
-        """A Dataset that is valid against the IATI Schema.
+        """A Dataset that is valid against the IATI Schema."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         return request.param
 
     @pytest.fixture(params=[
@@ -100,12 +88,9 @@ class ValidationTestBase(object):
         iati.tests.resources.load_as_dataset('invalid_iati_missing_required_element_from_common', '2.02')
     ])
     def not_iati_dataset_missing_required_el(self, request):
-        """A Dataset that is not valid against the IATI Schema because it is missing a required element.
+        """A Dataset that is not valid against the IATI Schema because it is missing a required element."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         return request.param
 
     @pytest.fixture
@@ -354,13 +339,10 @@ class ValidateCodelistsBase(ValidationTestBase):
     """A container for fixtures required for Codelist validation tests."""
 
     @pytest.fixture
-    def schema_version(self):
-        """Return an Activity Schema with the Version Codelist added.
+    def schema_version(self, request):
+        """Return an Activity Schema with the Version Codelist added."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         schema = iati.default.activity_schema('2.02', False)
         codelist = iati.default.codelist('Version', '2.02')
 
@@ -369,13 +351,10 @@ class ValidateCodelistsBase(ValidationTestBase):
         return schema
 
     @pytest.fixture
-    def schema_org_type(self):
-        """Return an Activity Schema with the OrganisationType Codelist added.
+    def schema_org_type(self, request):
+        """Return an Activity Schema with the OrganisationType Codelist added."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         schema = iati.default.activity_schema('2.02', False)
         codelist = iati.default.codelist('OrganisationType', '2.02')
 
@@ -384,13 +363,10 @@ class ValidateCodelistsBase(ValidationTestBase):
         return schema
 
     @pytest.fixture
-    def schema_incomplete_codelist(self):
-        """Return an Activity Schema with an incomplete Codelist added.
+    def schema_incomplete_codelist(self, request):
+        """Return an Activity Schema with an incomplete Codelist added."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         schema = iati.default.activity_schema('2.02', False)
         codelist = iati.default.codelist('Country', '2.02')
 
@@ -399,13 +375,10 @@ class ValidateCodelistsBase(ValidationTestBase):
         return schema
 
     @pytest.fixture
-    def schema_short_mapping_codelist(self):
-        """Return an Activity Schema with a Codelist that has a short `path` in the mapping file.
+    def schema_short_mapping_codelist(self, request):
+        """Return an Activity Schema with a Codelist that has a short `path` in the mapping file."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         schema = iati.default.activity_schema('2.02', False)
         codelist = iati.default.codelist('Language', '2.02')
 
@@ -414,13 +387,10 @@ class ValidateCodelistsBase(ValidationTestBase):
         return schema
 
     @pytest.fixture
-    def schema_sectors(self):
-        """Return an Activity Schema with the DAC Sector Codelists and appropriate vocabulary added.
+    def schema_sectors(self, request):
+        """Return an Activity Schema with the DAC Sector Codelists and appropriate vocabulary added."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         schema = iati.default.activity_schema('2.02', False)
 
         codelist_1 = iati.default.codelist('SectorVocabulary', '2.02')
@@ -434,13 +404,10 @@ class ValidateCodelistsBase(ValidationTestBase):
         return schema
 
     @pytest.fixture
-    def schema_element_text_codelist(self):
-        """Return an Activity Schema with a Codelist that maps to an element rather than attribute in the mapping file.
+    def schema_element_text_codelist(self, request):
+        """Return an Activity Schema with a Codelist that maps to an element rather than attribute in the mapping file."""
+        request.applymarker(pytest.mark.fixed_to_202)
 
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
         schema = iati.default.activity_schema('2.02', False)
         codelist = iati.default.codelist('CRSChannelCode', '2.02')
 
@@ -452,13 +419,9 @@ class ValidateCodelistsBase(ValidationTestBase):
 class TestValidationTruthyIATI(ValidationTestBase):
     """A container for tests relating to truthy validation of IATI data."""
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_valid(self, schema_basic):
-        """Perform a super simple data validation against a valid Dataset.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform a super simple data validation against a valid Dataset."""
         data = iati.tests.resources.load_as_dataset('valid_iati', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
@@ -505,39 +468,27 @@ class TestValidationTruthyIATI(ValidationTestBase):
         assert not iati.validator.is_iati_xml(data, schema_basic)
         assert not iati.validator.is_valid(data, schema_basic)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_invalid_missing_required_element(self, schema_basic):
-        """Perform a super simple data validation against a Dataset that is invalid due to a missing required element.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform a super simple data validation against a Dataset that is invalid due to a missing required element."""
         data = iati.tests.resources.load_as_dataset('invalid_iati_missing_required_element', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert not iati.validator.is_iati_xml(data, schema_basic)
         assert not iati.validator.is_valid(data, schema_basic)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_invalid_missing_required_element_from_common(self, schema_basic):
-        """Perform a super simple data validation against a Dataset that is invalid due to a missing required element that is defined in iati-common.xsd.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform a super simple data validation against a Dataset that is invalid due to a missing required element that is defined in iati-common.xsd."""
         data = iati.tests.resources.load_as_dataset('invalid_iati_missing_required_element_from_common', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert not iati.validator.is_iati_xml(data, schema_basic)
         assert not iati.validator.is_valid(data, schema_basic)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_fully_populated_schema(self, schema_fully_populated):
-        """Perform validation against a minimal valid Dataset when validated against a fully populated Schema.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform validation against a minimal valid Dataset when validated against a fully populated Schema."""
         data = iati.tests.resources.load_as_dataset('valid_iati_minimal_file', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
@@ -744,26 +695,18 @@ class TestIsValidIATIXML(ValidationTestBase):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-iati-xml-missing-required-element')
 
+    @pytest.mark.fixed_to_202
     def test_iati_xml_from_ssot_valid(self, schema_basic, error_log_empty):
-        """Perform check to see whether valid XML from the SSOT can be loaded and validated.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform check to see whether valid XML from the SSOT can be loaded and validated."""
         data = iati.tests.resources.load_as_dataset('ssot-activity-xml-pass/location/01-generic-location', '2.02')
 
         result = iati.validator.validate_is_iati_xml(data, schema_basic)
 
         assert result == error_log_empty
 
+    @pytest.mark.fixed_to_202
     def test_iati_xml_from_ssot_invalid(self, schema_basic):
-        """Perform check to see whether invalid XML from the SSOT can be loaded and validated.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform check to see whether invalid XML from the SSOT can be loaded and validated."""
         data = iati.tests.resources.load_as_dataset('ssot-activity-xml-fail/other-identifier/01-missing-attribute-type', '2.02')
 
         result = iati.validator.validate_is_iati_xml(data, schema_basic)
@@ -774,65 +717,45 @@ class TestIsValidIATIXML(ValidationTestBase):
 class TestValidationCodelist(ValidateCodelistsBase):
     """A container for tests relating to validation of Codelists."""
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_valid(self, schema_version):
-        """Perform data validation against valid IATI XML that has valid Codelist values.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has valid Codelist values."""
         data = iati.tests.resources.load_as_dataset('valid_iati', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_version)
         assert iati.validator.is_valid(data, schema_version)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_invalid(self, schema_version):
-        """Perform data validation against valid IATI XML that has invalid Codelist values.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has invalid Codelist values."""
         data = iati.tests.resources.load_as_dataset('valid_iati_invalid_code', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_version)
         assert not iati.validator.is_valid(data, schema_version)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_valid_from_common(self, schema_org_type):
-        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd."""
         data = iati.tests.resources.load_as_dataset('valid_iati_valid_code_from_common', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_org_type)
         assert iati.validator.is_valid(data, schema_org_type)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_invalid_from_common(self, schema_org_type):
-        """Perform data validation against valid IATI XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd."""
         data = iati.tests.resources.load_as_dataset('valid_iati_invalid_code_from_common', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_org_type)
         assert not iati.validator.is_valid(data, schema_org_type)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codes_valid_multi_use_codelist(self, schema_org_type):
-        """Perform data validation against valid IATI XML that has valid Codelist values. The attributes being tested are under different elements, but require the same Codelist.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has valid Codelist values. The attributes being tested are under different elements, but require the same Codelist."""
         data = iati.tests.resources.load_as_dataset('valid_iati_valid_codes_multiple_xpaths_for_codelist', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
@@ -843,75 +766,52 @@ class TestValidationCodelist(ValidateCodelistsBase):
         iati.tests.resources.load_as_dataset('valid_iati_invalid_codes_multiple_xpaths_for_codelist_first', '2.02'),
         iati.tests.resources.load_as_dataset('valid_iati_invalid_codes_multiple_xpaths_for_codelist_second', '2.02')
     ])
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codes_invalid_multi_use_codelist(self, data, schema_org_type):
-        """Perform data validation against valid IATI XML that has invalid Codelist values. The attributes being tested are under different elements, but require the same Codelist.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has invalid Codelist values. The attributes being tested are under different elements, but require the same Codelist."""
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_org_type)
         assert not iati.validator.is_valid(data, schema_org_type)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_incomplete_present(self, schema_incomplete_codelist):
-        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is on the list.
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is on the list."""
         data = iati.tests.resources.load_as_dataset('valid_iati_incomplete_codelist_code_present', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_incomplete_codelist)
         assert iati.validator.is_valid(data, schema_incomplete_codelist)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_incomplete_not_present(self, schema_incomplete_codelist):
-        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is not on the list.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is not on the list."""
         data = iati.tests.resources.load_as_dataset('valid_iati_incomplete_codelist_code_not_present', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_incomplete_codelist)
         assert iati.validator.is_valid(data, schema_incomplete_codelist)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_short_mapping_xpath(self, schema_short_mapping_codelist):
-        """Perform data validation against valid IATI XML. The attribute being tested refers to a Codelist with an abnormally short mapping file path. The data has no attributes mapped to by the Codelist.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML. The attribute being tested refers to a Codelist with an abnormally short mapping file path. The data has no attributes mapped to by the Codelist."""
         data = iati.tests.resources.load_as_dataset('valid_iati', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_short_mapping_codelist)
         assert iati.validator.is_valid(data, schema_short_mapping_codelist)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_code_from_element_valid(self, schema_element_text_codelist):
-        """Perform data validation against valid IATI XML. The Codelist being tested is being checked against an element text rather than an attribute.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML. The Codelist being tested is being checked against an element text rather than an attribute."""
         data = iati.tests.resources.load_as_dataset('valid_iati_codelist_mapping_element_text_valid_code', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_element_text_codelist)
         assert iati.validator.is_valid(data, schema_element_text_codelist)
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_codelist_code_from_element_invalid(self, schema_element_text_codelist):
-        """Perform data validation against valid IATI XML. The Codelist being tested is being checked against an element text rather than an attribute.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML. The Codelist being tested is being checked against an element text rather than an attribute."""
         data = iati.tests.resources.load_as_dataset('valid_iati_codelist_mapping_element_text_invalid_code', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
@@ -922,68 +822,49 @@ class TestValidationCodelist(ValidateCodelistsBase):
 class TestValidationVocabularies(ValidateCodelistsBase):
     """A container for tests relating to validation of vocabularies and associated Codelists."""
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_default_implicit(self, schema_sectors):
-        """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set."""
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_default_implicit', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_default_implicit_invalid_code(self, schema_sectors):
-        """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set. The code is invalid.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set. The code is invalid."""
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_default_implicit_invalid_code', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert not iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_default_explicit(self, schema_sectors):
-        """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as the default value.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as the default value."""
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_default_explicit', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_non_default(self, schema_sectors):
-        """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary."""
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_non_default', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_multiple_same_valid(self, schema_sectors):
         """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies.
 
         The vocabulary used by each of these elements is the same.
         The codes are valid against the vocabularies.
         Percentages add up to 100.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
         """
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_multiple_same_valid', '2.02')
 
@@ -991,16 +872,13 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_multiple_different_valid(self, schema_sectors):
         """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies.
 
         The vocabulary used by each of these elements is different.
         The codes are valid against the vocabularies.
         Percentages add up to 100.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
         """
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_multiple_different_valid', '2.02')
 
@@ -1008,16 +886,13 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_multiple_same_invalid_code(self, schema_sectors):
         """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies.
 
         The vocabulary used by each of these elements is the same.
         The codes are valid against the vocabularies.
         Percentages add up to 100.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
         """
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_multiple_same_invalid_code', '2.02')
 
@@ -1025,16 +900,13 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert not iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_multiple_different_invalid_code(self, schema_sectors):
         """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies.
 
         The vocabulary used by each of these elements is different.
         The codes are valid against the vocabularies.
         Percentages add up to 100.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
         """
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_multiple_different_invalid_code', '2.02')
 
@@ -1042,13 +914,9 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_iati_xml(data, schema_sectors)
         assert not iati.validator.is_valid(data, schema_sectors)
 
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_user_defined(self, schema_sectors):
-        """Perform data validation against valid IATI XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_user_defined', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
@@ -1056,13 +924,9 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_valid(data, schema_sectors)
 
     @pytest.mark.skip(reason="Not yet implemented - need to be able to load Codelists from URLs")
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_user_defined_with_uri_readable(self, schema_sectors):
-        """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid."""
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_user_defined_with_uri_readable', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
@@ -1070,13 +934,12 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_valid(data, schema_sectors)
 
     @pytest.mark.skip(reason="Not yet implemented - need to be able to load Codelists from URLs")
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_user_defined_with_uri_readable_bad_code(self, schema_sectors):
         """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is not in the list.
 
         Todo:
             Check that this is a legitimate check to be performed, given the contents and guidance given in the Standard.
-
-            Stop this being fixed to 2.02.
         """
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_user_defined_with_uri_readable_bad_code', '2.02')
 
@@ -1085,13 +948,12 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert not iati.validator.is_valid(data, schema_sectors)
 
     @pytest.mark.skip(reason="Not yet implemented - need to be able to load Codelists from URLs")
+    @pytest.mark.fixed_to_202
     def test_validation_codelist_vocab_user_defined_with_uri_unreadable(self, schema_sectors):
         """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a non-machine-readable codelist. As such, the @code cannot be checked. The @code is valid.
 
         Todo:
             Remove xfail and work on functionality to fully fetch and parse user-defined codelists after higher priority functionality is finished.
-
-            Stop this being fixed to 2.02.
         """
         data = iati.tests.resources.load_as_dataset('valid_iati_vocab_user_defined_with_uri_unreadable', '2.02')
 
@@ -1103,13 +965,9 @@ class TestValidationVocabularies(ValidateCodelistsBase):
 class TestValidateRulesets(object):
     """A container for tests relating to validation of Rulesets."""
 
+    @pytest.mark.fixed_to_202
     def test_basic_validation_ruleset_valid(self, schema_ruleset):
-        """Perform data validation against valid IATI XML that is valid against the Standard Ruleset.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that is valid against the Standard Ruleset."""
         data = iati.tests.resources.load_as_dataset('valid_std_ruleset', '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
@@ -1122,39 +980,27 @@ class TestValidateRulesets(object):
         'ruleset-std/invalid_std_ruleset_does_not_sum_100',
         'ruleset-std/invalid_std_ruleset_missing_sector_element'
     ])
+    @pytest.mark.fixed_to_202
     def test_basic_validation_ruleset_invalid(self, schema_ruleset, invalid_xml_file):
-        """Perform data validation against valid IATI XML that does not conform to the Standard Ruleset.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that does not conform to the Standard Ruleset."""
         data = iati.tests.resources.load_as_dataset(invalid_xml_file, '2.02')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_ruleset)
         assert not iati.validator.is_valid(data, schema_ruleset)
 
+    @pytest.mark.fixed_to_202
     def test_one_ruleset_error_added_for_multiple_rule_errors(self, schema_ruleset):
-        """Check that a Dataset containing multiple Rule errors produces an error log containing only one Ruleset error.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Dataset containing multiple Rule errors produces an error log containing only one Ruleset error."""
         data_with_multiple_rule_errors = iati.tests.resources.load_as_dataset('ruleset-std/invalid_std_ruleset_multiple_rule_errors', '2.02')
         result = iati.validator.full_validation(data_with_multiple_rule_errors, schema_ruleset)
 
         assert len(result.get_errors_or_warnings_by_category('rule')) > 1
         assert len(result.get_errors_or_warnings_by_name('err-ruleset-conformance-fail')) == 1
 
+    @pytest.mark.fixed_to_202
     def test_multiple_ruleset_error_added_for_multiple_rulesets(self):
-        """Check that a Schema containing multiple Rulesets produces an error log containing multiple Ruleset errors when each errors.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Schema containing multiple Rulesets produces an error log containing multiple Ruleset errors when each errors."""
         data_with_multiple_rule_errors = iati.tests.resources.load_as_dataset('ruleset-std/invalid_std_ruleset_multiple_rule_errors', '2.02')
         ruleset_1 = iati.default.ruleset('2.02')
         ruleset_2 = iati.default.ruleset('2.02')
@@ -1167,13 +1013,9 @@ class TestValidateRulesets(object):
         assert len(result.get_errors_or_warnings_by_category('rule')) > 1
         assert len(result.get_errors_or_warnings_by_name('err-ruleset-conformance-fail')) == 2
 
+    @pytest.mark.fixed_to_202
     def test_no_ruleset_errors_added_for_rule_warnings(self, schema_ruleset):
-        """Check that a Dataset containing only Rule warnings does not result in a Ruleset error being added.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Check that a Dataset containing only Rule warnings does not result in a Ruleset error being added."""
         data_with_rule_warnings_only = iati.tests.resources.load_as_dataset('valid_std_ruleset', '2.02')
 
         result = iati.validator.full_validation(data_with_rule_warnings_only, schema_ruleset)
@@ -1205,24 +1047,16 @@ class TestValidatorFullValidation(ValidateCodelistsBase):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-iati-xml-missing-required-element')
 
+    @pytest.mark.fixed_to_202
     def test_full_validation_codelist_valid_detailed_output(self, schema_version):
-        """Perform data validation against valid IATI XML that has valid Codelist values.  Obtain detailed error output.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has valid Codelist values.  Obtain detailed error output."""
         data = iati.tests.resources.load_as_dataset('valid_iati', '2.02')
 
         assert iati.validator.full_validation(data, schema_version) == iati.validator.ValidationErrorLog()
 
+    @pytest.mark.fixed_to_202
     def test_full_validation_codelist_invalid_detailed_output(self, schema_version):
-        """Perform data validation against valid IATI XML that has invalid Codelist values.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
-        """
+        """Perform data validation against valid IATI XML that has invalid Codelist values."""
         xml_str = iati.tests.resources.load_as_string('valid_iati_invalid_code', '2.02')
         data = iati.Dataset(xml_str)
 
@@ -1236,13 +1070,10 @@ class TestValidatorFullValidation(ValidateCodelistsBase):
         assert 'Version' in result.info
         assert 'Version' in result.help
 
+    @pytest.mark.fixed_to_202
     def test_full_validation_codelist_incomplete_present_detailed_output(self, schema_incomplete_codelist, error_log_empty):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is on the list.
         Obtain detailed error output.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
         """
         data = iati.tests.resources.load_as_dataset('valid_iati_incomplete_codelist_code_present', '2.02')
 
@@ -1250,13 +1081,10 @@ class TestValidatorFullValidation(ValidateCodelistsBase):
 
         assert result == error_log_empty
 
+    @pytest.mark.fixed_to_202
     def test_full_validation_codelist_incomplete_not_present_detailed_output(self, schema_incomplete_codelist):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is not on the list.
         Obtain detailed error output.
-
-        Todo:
-            Stop this being fixed to 2.02.
-
         """
         xml_str = iati.tests.resources.load_as_string('valid_iati_incomplete_codelist_code_not_present', '2.02')
         data = iati.Dataset(xml_str)

--- a/iati/tests/utilities.py
+++ b/iati/tests/utilities.py
@@ -19,20 +19,6 @@ SCHEMA_NAME_VALID = 'iati-activities-schema'
 
 XML_TREE_VALID = iati.utilities.load_as_tree(iati.tests.resources.get_test_data_path('valid_not_iati'))
 """An etree that is valid XML but not IATI XML."""
-XML_TREE_VALID_IATI = iati.utilities.load_as_tree(iati.tests.resources.get_test_data_path('valid_iati', '2.02'))
-"""A valid IATI etree.
-
-Todo:
-    Stop this being fixed to 2.02.
-
-"""
-XML_TREE_VALID_IATI_INVALID_CODE = iati.utilities.load_as_tree(iati.tests.resources.get_test_data_path('valid_iati_invalid_code', '2.02'))
-"""A valid IATI etree that has an invalid Code value.
-
-Todo:
-    Stop this being fixed to 2.02.
-
-"""
 
 
 _BYTES_VALS = [b'\x80abc', b'\x80abc']

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,7 @@ add_select = D212,D404
 convention = pep257
 
 [tool:pytest]
+markers =
+    fixed_to_202: mark that a test only uses v2.02 data, and could possibly be updated in the future to either be version-agnostic or test a wider range of versions
 testpaths = iati
 


### PR DESCRIPTION
As part of the version migration, it became necessary to explicitly specify versions rather than 'None' meaning 'latest version'. Locations where this happen had a TODO added. This led to things being a bit unclear.

Markers are now used to highlight where this happens.