### PR TITLE
Fixes blank line contains whitespace linting error

### DIFF
--- a/iati/version.py
+++ b/iati/version.py
@@ -50,9 +50,8 @@ class Version(semantic_version.Version):
     @property
     def decimal(self):
         """int: The IATIver Decimal Component of the Version.
-        
-        This differs from the minor component since it starts at .01 (1) rather than .0 (0).
 
+        This differs from the minor component since it starts at .01 (1) rather than .0 (0).
         """
         return self.minor + 1
 


### PR DESCRIPTION
Resolves linting errors in #273 - shown in (Travis build 2741](https://travis-ci.org/IATI/pyIATI/builds/355385616).

**pylint**
```
$ make pylint
pylint iati/
Using config file /home/travis/build/IATI/pyIATI/.pylintrc
************* Module iati.version
C: 53, 0: Trailing whitespace (trailing-whitespace)
```

**flake8**
```
$ make flake8
flake8 iati/
iati/version.py:53:1: W293 blank line contains whitespace
```