### PR TITLE
Remove python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache:
     pip
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [Resources] Functions in the `resources` module no longer have default values for the `version` argument. [#297]
 
+- [Compatibility] Drop support for Python 3.4. [#309]
+
 ### Fixed
 
 - [Constants] `STANDARD_VERSIONS` now lists all versions of the Standard, not just those that are fully supported by pyIATI. [#223]

--- a/iati/resources.py
+++ b/iati/resources.py
@@ -462,7 +462,7 @@ def path_for_version(path, version):
         Does not check whether anything exists at the specified path.
 
     """
-    try:  # python2 and python3.4 compatibility
+    try:  # python2 compatibility
         _ensure_portable_filepath(path)
     except ValueError:
         if path != '':
@@ -516,7 +516,7 @@ def _ensure_portable_filepath(maybe_filepath):
         This restriction is currently tight since it's easier to tighten than loosen restrictions. The restriction could be relaxed over time.
 
     Todo:
-        Consider utilising the Python3.4 concept of path-like objects.
+        Consider utilising the Python3 concept of path-like objects from the pathlib module.
 
     """
     if not isinstance(maybe_filepath, str):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering :: Information Analysis',


### PR DESCRIPTION
Fixes #300

The reasons for removal are details in #300
At this very point, the code still works with Python 3.4. Testing against this version, however, is being stopped. This means that at some unknown point in the future pyIATI will stop working with Python 3.4.