### PR TITLE
Remove python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 cache:
     pip
 python:
-  - 2.7
   - 3.4
   - 3.5
   - 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - [Resources] Functions in the `resources` module no longer have default values for the `version` argument. [#297]
 
+- [Compatibility] Drop support for Python 2.7.
+
 ### Fixed
 
 - [Constants] `STANDARD_VERSIONS` now lists all versions of the Standard, not just those that are fully supported by pyIATI. [#223]

--- a/iati/codelists.py
+++ b/iati/codelists.py
@@ -5,7 +5,7 @@ import iati.resources
 import iati.utilities
 
 
-class Codelist(object):
+class Codelist:
     """Representation of a Codelist as defined within the IATI SSOT.
 
     Attributes:
@@ -165,7 +165,7 @@ class Codelist(object):
         return type_base_el
 
 
-class Code(object):
+class Code:
     """Representation of a Code contained within a Codelist.
 
     Attributes:

--- a/iati/data.py
+++ b/iati/data.py
@@ -1,12 +1,11 @@
 """A module containing a core representation of an IATI Dataset."""
-import sys
 from lxml import etree
 import iati.exceptions
 import iati.utilities
 import iati.validator
 
 
-class Dataset(object):
+class Dataset:
     """Representation of an IATI XML file that may be validated against a Schema.
 
     Attributes:
@@ -89,10 +88,9 @@ class Dataset(object):
                 validation_error_log = iati.validator.validate_is_xml(value_stripped)
 
                 # Convert the input to bytes, as etree.fromstring works most consistently with bytes objects, especially if an XML encoding declaration has been used.
-                if (isinstance(value_stripped, str) and
-                        sys.version_info.major > 2):  # Python v2 treats strings as byte objects by default
+                if isinstance(value_stripped, str):
                     value_stripped_bytes = value_stripped.encode()
-                else:
+                elif isinstance(value_stripped, bytes):
                     value_stripped_bytes = value_stripped
 
                 if not validation_error_log.contains_errors():

--- a/iati/resources.py
+++ b/iati/resources.py
@@ -230,10 +230,7 @@ def _get_paths(version, file_name, path_creation_func, supported_versions):
         # major version
         versions = [minor_ver for minor_ver in iati.version.versions_for_integer(int(version)) if minor_ver in supported_versions]
 
-    try:
-        num_path_creation_func_args = len(inspect.getfullargspec(path_creation_func).args)
-    except AttributeError:  # python2/3 compatiblity: getfullargspec added at v3, while getargspec was deprecated
-        num_path_creation_func_args = len(inspect.getargspec(path_creation_func).args)
+    num_path_creation_func_args = len(inspect.getfullargspec(path_creation_func).args)
 
     for minor_ver in versions:
         try:
@@ -273,7 +270,7 @@ def create_codelist_path(codelist_name, version):
         It needs to be determined how best to locate a user-defined Codelist that is available at a URL that needs fetching.
 
     """
-    _ensure_portable_filepath(codelist_name)  # required for python2 compatibility
+    _ensure_portable_filepath(codelist_name)
 
     if codelist_name[-4:] == FILE_CODELIST_EXTENSION:
         codelist_name = codelist_name[:-4]
@@ -322,7 +319,7 @@ def create_lib_data_path(name):
         Does not check whether the specified file actually exists.
 
     """
-    _ensure_portable_filepath(name)  # required for python2 compatibility
+    _ensure_portable_filepath(name)
 
     return resource_filesystem_path(os.path.join(BASE_PATH_LIB_DATA, name))
 
@@ -462,7 +459,7 @@ def path_for_version(path, version):
         Does not check whether anything exists at the specified path.
 
     """
-    try:  # python2 and python3.4 compatibility
+    try:
         _ensure_portable_filepath(path)
     except ValueError:
         if path != '':

--- a/iati/resources/lib_data/validation_err_codes.yaml
+++ b/iati/resources/lib_data/validation_err_codes.yaml
@@ -3,7 +3,7 @@
 # The structure of a code is:
 #
 #   - name-of-the-error-or-warning:
-#       base_exception: The name of a Python exception that the error code represents. Should be valid for both Python 2 and Python 3. https://docs.python.org/2/library/exceptions.html#exception-hierarchy
+#       base_exception: The name of a Python exception that the error code represents. Should be valid for Python 3. https://docs.python.org/3/library/exceptions.html#exception-hierarchy
 #       category: The high level category that the error falls into.
 #       description: |-
 #           A short general description of the error that has occurred.

--- a/iati/schemas.py
+++ b/iati/schemas.py
@@ -8,7 +8,7 @@ import iati.resources
 import iati.utilities
 
 
-class Schema(object):
+class Schema:
     """Representation of a Schema as defined within the IATI SSOT. This is used as a base class for ActivitySchema and OrganisationSchema and should not be instantiated directly.
 
     Attributes:

--- a/iati/tests/fixtures/filepaths.py
+++ b/iati/tests/fixtures/filepaths.py
@@ -26,7 +26,7 @@ def filename_no_meaning_single(request):
 def filepath_invalid_type(request):
     """Return a value that is of a type that cannot represent a filepath.
 
-    Python2/3 compatibility: Look at using the concept of PathLike that was introduced at 3.4.
+    Python3 compatibility: Look at using the concept of PathLike that was introduced at 3.4.
     """
     return request.param
 

--- a/iati/tests/resources.py
+++ b/iati/tests/resources.py
@@ -125,7 +125,7 @@ def load_as_string(relative_path, version=iati.version.STANDARD_VERSION_ANY):
         version (str): The version of the Standard to return the data files for. Defaults to iati.version.STANDARD_VERSION_ANY.
 
     Returns:
-        str (python3) / unicode (python2): The contents of the file at the specified location.
+        str: The contents of the file at the specified location.
 
     """
     path = iati.tests.resources.get_test_data_path(relative_path, version)

--- a/iati/tests/test_codelists.py
+++ b/iati/tests/test_codelists.py
@@ -5,7 +5,7 @@ from lxml import etree
 import iati.codelists
 
 
-class TestCodelistsNonClass(object):
+class TestCodelistsNonClass:
     """Test codelists functionality that is not contained within a class.
 
     Note:
@@ -15,7 +15,7 @@ class TestCodelistsNonClass(object):
     pass
 
 
-class TestCodelists(object):
+class TestCodelists:
     """A container for tests relating to Codelists."""
 
     @pytest.fixture
@@ -123,7 +123,7 @@ class TestCodelists(object):
         assert type_tree[0][0].nsmap == iati.constants.NSMAP
 
 
-class TestCodes(object):
+class TestCodes:
     """A container for tests relating to Codes."""
 
     def test_code_no_attributes(self):
@@ -166,7 +166,7 @@ class TestCodes(object):
         assert enum_el.nsmap == iati.constants.NSMAP
 
 
-class TestCodelistEquality(object):
+class TestCodelistEquality:
     """A container for tests relating to Codelist equality - both direct and via hashing."""
 
     @pytest.mark.parametrize('codelist', iati.default.codelists('2.02').values())

--- a/iati/tests/test_constants.py
+++ b/iati/tests/test_constants.py
@@ -2,7 +2,7 @@
 import iati.constants
 
 
-class TestConstants(object):
+class TestConstants:
     """A container for tests relating to IATI software constants."""
 
     def test_namespace(self):

--- a/iati/tests/test_data.py
+++ b/iati/tests/test_data.py
@@ -5,18 +5,14 @@ Todo:
 """
 import collections
 import math
-import sys
-from future.standard_library import install_aliases
 from lxml import etree
 import pytest
 import iati.data
 import iati.default
 import iati.tests.utilities
 
-install_aliases()
 
-
-class TestDatasets(object):
+class TestDatasets:
     """A container for tests relating to Datasets."""
 
     @pytest.fixture
@@ -181,7 +177,7 @@ class TestDatasets(object):
         assert 'If setting a Dataset with the xml_property, an ElementTree should be provided, not a' in str(excinfo.value)
 
 
-class TestDatasetWithEncoding(object):
+class TestDatasetWithEncoding:
     """A container for tests relating to creating a Dataset from various types of input.
 
     This may be files vs strings, or may revolve around character encoding.
@@ -236,17 +232,11 @@ class TestDatasetWithEncoding(object):
         """Test that an encoded Dataset instantiated directly from a string (rather than a file or bytes object) correctly creates an iati.data.Dataset and the input data is contained within the object."""
         xml = xml_needing_encoding_use_as_str.format('UTF-8')
 
-        if sys.version_info.major > 2:
-            with pytest.raises(iati.exceptions.ValidationError) as validation_err:
-                iati.data.Dataset(xml)
+        with pytest.raises(iati.exceptions.ValidationError) as validation_err:
+            iati.data.Dataset(xml)
 
-            assert len(validation_err.value.error_log) == 1
-            assert validation_err.value.error_log.contains_error_called('err-encoding-in-str')
-        else:
-            dataset = iati.data.Dataset(xml)
-
-            assert isinstance(dataset, iati.data.Dataset)
-            assert dataset.xml_str == xml.strip()
+        assert len(validation_err.value.error_log) == 1
+        assert validation_err.value.error_log.contains_error_called('err-encoding-in-str')
 
     @pytest.mark.parametrize("encoding", [
         "UTF-8",
@@ -323,7 +313,7 @@ class TestDatasetWithEncoding(object):
         assert excinfo.value.error_log.contains_error_called('err-encoding-unsupported')
 
 
-class TestDatasetSourceFinding(object):
+class TestDatasetSourceFinding:
     """A container for tests relating to finding source context within a Dataset."""
 
     @pytest.fixture(params=[
@@ -498,7 +488,7 @@ class TestDatasetSourceFinding(object):
                 data.source_around_line(line_num, invalid_value)
 
 
-class TestDatasetVersionDetection(object):
+class TestDatasetVersionDetection:
     """A container for tests relating to detecting the version of a Dataset."""
 
     @pytest.fixture(params=[

--- a/iati/tests/test_default.py
+++ b/iati/tests/test_default.py
@@ -7,7 +7,7 @@ import iati.schemas
 import iati.tests.utilities
 
 
-class TestDefault(object):
+class TestDefault:
     """A container for tests relating to Default data."""
 
     @pytest.fixture(params=[
@@ -33,7 +33,7 @@ class TestDefault(object):
         assert default_data_func_version_param(std_ver_major_uninst_valid_known) == default_data_func_version_param(minor_version)
 
 
-class TestDefaultCodelists(object):
+class TestDefaultCodelists:
     """A container for tests relating to default Codelists."""
 
     @pytest.fixture(params=[
@@ -204,7 +204,7 @@ class TestDefaultCodelists(object):
         assert len(codelists) == codelist_lengths_by_version.expected_length
 
 
-class TestDefaultRulesets(object):
+class TestDefaultRulesets:
     """A container for tests relating to default Rulesets."""
 
     def test_default_ruleset(self, std_ver_minor_mixedinst_valid_fullsupport):
@@ -277,7 +277,7 @@ class TestDefaultRulesets(object):
         assert info_text in errors_for_rule_error[0].info
 
 
-class TestDefaultSchemas(object):
+class TestDefaultSchemas:
     """A container for tests relating to default Schemas."""
 
     def test_default_activity_schemas(self, std_ver_minor_mixedinst_valid_fullsupport):
@@ -326,7 +326,7 @@ class TestDefaultSchemas(object):
         assert schema.rulesets == set()
 
 
-class TestDefaultModifications(object):
+class TestDefaultModifications:
     """A container for tests relating to the ability to modify defaults."""
 
     @pytest.fixture

--- a/iati/tests/test_resources.py
+++ b/iati/tests/test_resources.py
@@ -12,7 +12,7 @@ import iati.version
 import iati.tests.resources
 
 
-class TestResourceConstants(object):
+class TestResourceConstants:
     """A container for tests relating to checks of resource constants."""
 
     @pytest.mark.parametrize('folder_path', [
@@ -70,7 +70,7 @@ class TestResourceConstants(object):
         assert re.match(file_extension_regex, file_extension)
 
 
-class TestResourceFilesystemPaths(object):
+class TestResourceFilesystemPaths:
     """A container for tests relating to specific filesystem paths."""
 
     def test_resource_filesystem_path(self, filename_no_meaning):
@@ -101,7 +101,7 @@ class TestResourceFilesystemPaths(object):
         assert os.path.isdir(full_path)
 
 
-class TestResourceLibData(object):
+class TestResourceLibData:
     """A container for tests relating to handling paths for pyIATI library-specific data."""
 
     def test_create_lib_data_path(self, filename_no_meaning):
@@ -112,7 +112,7 @@ class TestResourceLibData(object):
         assert full_path.endswith(filename_no_meaning)
 
 
-class TestResourceHandlingInvalidPaths(object):
+class TestResourceHandlingInvalidPaths:
     """A container for tests relating to handling paths that are invalid and being passed to functions that are version-independent."""
 
     @pytest.fixture(params=[
@@ -139,7 +139,7 @@ class TestResourceHandlingInvalidPaths(object):
             resource_func(filepath_invalid_type)
 
 
-class TestResourcePathComponents(object):
+class TestResourcePathComponents:
     """A container for tests relating to generation of component parts of a resource path."""
 
     @pytest.mark.parametrize('version, expected_version_foldername', [
@@ -205,7 +205,7 @@ class TestResourcePathComponents(object):
             iati.resources.folder_name_for_version()  # pylint: disable=no-value-for-parameter
 
 
-class TestResoucePathCreationEntireStandard(object):
+class TestResoucePathCreationEntireStandard:
     """A container for tests relating to generating entire filepaths for any part of the Standard."""
 
     def test_folder_path_for_version_known(self, std_ver_any_mixedinst_valid_known):
@@ -281,7 +281,7 @@ class TestResoucePathCreationEntireStandard(object):
             iati.resources.path_for_version(filepath_invalid_type, std_ver_minor_inst_valid_single)
 
 
-class TestResourcePathCreationCodelistMapping(object):
+class TestResourcePathCreationCodelistMapping:
     """A container for tests relating to creating Codelist Mapping File paths."""
 
     def test_create_codelist_mapping_path_minor(self, std_ver_minor_mixedinst_valid_known):
@@ -323,7 +323,7 @@ class TestResourcePathCreationCodelistMapping(object):
             iati.resources.create_codelist_mapping_path(std_ver_all_uninst_typeerr)
 
 
-class TestResourcePathCreationCoreComponents(object):
+class TestResourcePathCreationCoreComponents:
     """A container for tests relating to path creation for core components in the IATI Standard.
 
     Core components include Codelists, Rulesets and Schemas.
@@ -419,7 +419,7 @@ class TestResourcePathCreationCoreComponents(object):
             func_to_test(filepath_invalid_type, std_ver_minor_inst_valid_single)
 
 
-class TestResourceGetCodelistPaths(object):
+class TestResourceGetCodelistPaths:
     """A container for get_codelist_paths() tests."""
 
     def test_find_codelist_paths(self, codelist_lengths_by_version):
@@ -463,7 +463,7 @@ class TestResourceGetCodelistPaths(object):
         assert result == []
 
 
-class TestResourceGetCodelistMappingPaths(object):
+class TestResourceGetCodelistMappingPaths:
     """A container for get_codelist_mapping_paths() tests.
 
     Note:
@@ -508,7 +508,7 @@ class TestResourceGetCodelistMappingPaths(object):
             assert iati.resources.create_codelist_mapping_path(version) in result
 
 
-class TestResourceGetRulesetPaths(object):
+class TestResourceGetRulesetPaths:
     """A container for get_ruleset_paths() tests."""
 
     def test_get_ruleset_paths_minor_fullsupport(self, std_ver_minor_mixedinst_valid_fullsupport):
@@ -549,7 +549,7 @@ class TestResourceGetRulesetPaths(object):
             assert iati.resources.create_ruleset_path(iati.resources.FILE_RULESET_STANDARD_NAME, version) in result
 
 
-class TestResourceGetSchemaPaths(object):
+class TestResourceGetSchemaPaths:
     """A container for get_x_schema_paths() tests."""
 
     @pytest.fixture(params=[
@@ -629,7 +629,7 @@ class TestResourceGetSchemaPaths(object):
             assert path in result
 
 
-class TestResourceGetPathsNotAVersion(object):
+class TestResourceGetPathsNotAVersion:
     """A container for get_*_paths() tests where the function is provided a value that cannot represent a version."""
 
     @pytest.fixture(params=[
@@ -660,7 +660,7 @@ class TestResourceGetPathsNotAVersion(object):
             func_to_test(std_ver_all_uninst_typeerr)
 
 
-class TestResourceTestDataFolders(object):
+class TestResourceTestDataFolders:
     """A container for tests relating to resource folders."""
 
     @pytest.mark.parametrize('version, expected_num_paths', [

--- a/iati/tests/test_rulesets.py
+++ b/iati/tests/test_rulesets.py
@@ -15,7 +15,7 @@ import iati.resources
 import iati.tests.utilities
 
 
-class RulesetFixtures(object):
+class RulesetFixtures:
     """A base class for fixtures to use in Ruleset tests."""
 
     empty_init_config = [
@@ -247,7 +247,7 @@ class TestRulesetEquality(RulesetFixtures):
         assert cmp_func_different_val_and_hash(ruleset, ruleset_copy)
 
 
-class TestRule(object):
+class TestRule:
     """A container for tests relating to Rules."""
 
     def test_rule_class_cannot_be_instantiated_directly_without_name(self):
@@ -268,7 +268,7 @@ class TestRule(object):
             iati.Rule(name, context, case)  # pylint: disable=too-many-function-args
 
 
-class TestRuleSubclasses(object):
+class TestRuleSubclasses:
     """A container for tests relating to all Rule subclasses."""
 
     @pytest.fixture(params=[
@@ -317,7 +317,7 @@ class TestRuleSubclasses(object):
             rule_constructor(context, case)
 
 
-class RuleSubclassFixtures(object):
+class RuleSubclassFixtures:
     """A base class for fixtures to use in Rule subclass tests."""
 
     @pytest.fixture

--- a/iati/tests/test_schemas.py
+++ b/iati/tests/test_schemas.py
@@ -11,7 +11,7 @@ import iati.schemas
 import iati.tests.utilities
 
 
-class SchemaTestsBase(object):
+class SchemaTestsBase:
     """A base class for all Schema tests."""
 
     @pytest.fixture(params=[

--- a/iati/tests/test_test.py
+++ b/iati/tests/test_test.py
@@ -1,7 +1,7 @@
 """A module containing tests to demonstrate that tests are working."""
 
 
-class TestTest(object):
+class TestTest:
     """Container to demonstrate that tests are running."""
 
     def test_trivial(self):

--- a/iati/tests/test_utilities.py
+++ b/iati/tests/test_utilities.py
@@ -1,13 +1,12 @@
 """A module containing tests for the library implementation of accessing utilities."""
 from lxml import etree
 import pytest
-import six
 import iati.resources
 import iati.tests.utilities
 import iati.utilities
 
 
-class TestUtilities(object):
+class TestUtilities:
     """A container for tests relating to utilities."""
 
     @pytest.fixture
@@ -193,7 +192,7 @@ class TestUtilities(object):
         pass
 
 
-class TestFileLoading(object):
+class TestFileLoading:
     """A container for tests relating to loading files."""
 
     @pytest.fixture(scope='session')
@@ -260,10 +259,10 @@ class TestFileLoading(object):
             _ = iati.utilities.load_as_dataset(invalid_xml_file_path)
 
     def test_load_as_string(self, invalid_xml_file_path):
-        """Test that `utilities.load_as_string()` returns a string (python3) or unicode (python2) object with the expected content."""
+        """Test that `utilities.load_as_string()` returns a string with the expected content."""
         result = iati.utilities.load_as_string(invalid_xml_file_path)
 
-        assert isinstance(result, six.string_types)
+        assert isinstance(result, str)
         assert result == 'This is a string that is not valid XML\n'
 
     @pytest.mark.parametrize("load_method", [
@@ -274,12 +273,6 @@ class TestFileLoading(object):
     def test_load_as_x_non_existing_file(self, load_method):
         """Test that `utilities.load_as_bytes()` returns a bytes object with the expected content."""
         path_test_data = iati.tests.resources.get_test_data_path('this-file-does-not-exist')
-
-        # python 2/3 compatibility - FileNotFoundError introduced at Python 3
-        try:
-            FileNotFoundError
-        except NameError:
-            FileNotFoundError = IOError  # pylint: disable=redefined-builtin,invalid-name
 
         with pytest.raises(FileNotFoundError):
             _ = load_method(path_test_data)
@@ -296,8 +289,7 @@ class TestFileLoading(object):
         str_of_interest = dataset.xml_tree.xpath('//reporting-org/narrative/text()')[0]
 
         # the character of interest is in windows-1252, but is different from ASCII
-        # python2/3 compatibility: encode string as UTF-8
-        assert str_of_interest.encode('utf-8') == b'\xc5\xb8'
+        assert str_of_interest.encode('UTF-8') == b'\xc5\xb8'
 
     @pytest.mark.parametrize("file_to_load", [
         'dataset-encoding/valid-UTF-8.xml',
@@ -317,8 +309,7 @@ class TestFileLoading(object):
         # the tested characters are all in the code range 004000-00FFFF
         # this means that they are 3-bit at UTF-8, 2 bit as UTF-16 and 4-bit as UTF-32 in 8-bit environments
         # https://en.wikipedia.org/wiki/Comparison_of_Unicode_encodings#Eight-bit_environments
-        # python2/3 compatibility: encode string as UTF-8
-        assert str_of_interest.encode('utf-8') == b'\xe4\xb6\x8c\xe4\xb9\xa8\xe4\xbc\xb6\xe4\xbe\x97\xe5\x80\x97\xe5\x82\x88\xe5\x84\x88\xe5\x89\x89\xe5\x94\x99\xe8\xac\x9c\xe8\xb0\x8b\xee\x82\xb1\xee\x82\xb2\xee\x82\xb3\xee\x82\xb5\xee\x82\xb8\xee\x82\xba\xee\x82\xbb\xee\x82\xbc\xee\x82\xbd\xee\x82\xbe\xee\x83\x8e\xee\x83\x8f\xee\x84\xa8\xee\x84\xa9\xe4\xb6\x8c\xe4\xb9\xa8\xe4\xbc\xb6\xe4\xbe\x97\xe5\x80\x97\xe5\x82\x88\xe5\x84\x88\xe5\x89\x89\xe5\x94\x99\xe8\xac\x9c\xe8\xb0\x8b\xee\x82\xb1\xee\x82\xb2\xee\x82\xb3\xee\x82\xb5\xee\x82\xb8\xee\x82\xba\xee\x82\xbb\xee\x82\xbc\xee\x82\xbd\xee\x82\xbe\xee\x83\x8e\xee\x83\x8f\xee\x84\xa8\xee\x84\xa9\xe4\xb6\x8c\xe4\xb9\xa8\xe4\xbc\xb6\xe4\xbe\x97\xe5\x80\x97\xe5\x82\x88\xe5\x84\x88\xe5\x89\x89\xe5\x94\x99\xe8\xac\x9c\xe8\xb0\x8b\xee\x82\xb1\xee\x82\xb2\xee\x82\xb3\xee\x82\xb5\xee\x82\xb8\xee\x82\xba\xee\x82\xbb\xee\x82\xbc\xee\x82\xbd\xee\x82\xbe\xee\x83\x8e\xee\x83\x8f\xee\x84\xa8\xee\x84\xa9'  # noqa: ignore=E501  # pylint: disable=line-too-long
+        assert str_of_interest.encode('UTF-8') == b'\xe4\xb6\x8c\xe4\xb9\xa8\xe4\xbc\xb6\xe4\xbe\x97\xe5\x80\x97\xe5\x82\x88\xe5\x84\x88\xe5\x89\x89\xe5\x94\x99\xe8\xac\x9c\xe8\xb0\x8b\xee\x82\xb1\xee\x82\xb2\xee\x82\xb3\xee\x82\xb5\xee\x82\xb8\xee\x82\xba\xee\x82\xbb\xee\x82\xbc\xee\x82\xbd\xee\x82\xbe\xee\x83\x8e\xee\x83\x8f\xee\x84\xa8\xee\x84\xa9\xe4\xb6\x8c\xe4\xb9\xa8\xe4\xbc\xb6\xe4\xbe\x97\xe5\x80\x97\xe5\x82\x88\xe5\x84\x88\xe5\x89\x89\xe5\x94\x99\xe8\xac\x9c\xe8\xb0\x8b\xee\x82\xb1\xee\x82\xb2\xee\x82\xb3\xee\x82\xb5\xee\x82\xb8\xee\x82\xba\xee\x82\xbb\xee\x82\xbc\xee\x82\xbd\xee\x82\xbe\xee\x83\x8e\xee\x83\x8f\xee\x84\xa8\xee\x84\xa9\xe4\xb6\x8c\xe4\xb9\xa8\xe4\xbc\xb6\xe4\xbe\x97\xe5\x80\x97\xe5\x82\x88\xe5\x84\x88\xe5\x89\x89\xe5\x94\x99\xe8\xac\x9c\xe8\xb0\x8b\xee\x82\xb1\xee\x82\xb2\xee\x82\xb3\xee\x82\xb5\xee\x82\xb8\xee\x82\xba\xee\x82\xbb\xee\x82\xbc\xee\x82\xbd\xee\x82\xbe\xee\x83\x8e\xee\x83\x8f\xee\x84\xa8\xee\x84\xa9'  # noqa: ignore=E501  # pylint: disable=line-too-long
 
     @pytest.mark.parametrize("file_to_load", [
         'dataset-encoding/valid-undetectable-encoding.xml'

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -1,6 +1,5 @@
 """A module containing tests for data validation."""
 # pylint: disable=too-many-lines
-import sys
 import pytest
 import iati.data
 import iati.default
@@ -9,7 +8,7 @@ import iati.tests.utilities
 import iati.validator
 
 
-class ValidationTestBase(object):
+class ValidationTestBase:
     """A container for fixtures and other functionality useful among multiple groups of Validation Test."""
 
     @pytest.fixture
@@ -67,13 +66,9 @@ class ValidationTestBase(object):
         """A value that is not a valid XML string."""
         return request.param
 
-    @pytest.fixture(params=['This is a string that is not XML.'])
+    @pytest.fixture(params=iati.tests.utilities.generate_test_types(['str']))
     def str_not_xml(self, request):
-        """A string that is not XML.
-
-        Note:
-            Does not use the utility function due to problems with Python 2.7.
-        """
+        """A string that is not XML."""
         return request.param
 
     @pytest.fixture
@@ -118,7 +113,7 @@ class ValidationTestBase(object):
         return iati.validator.ValidationErrorLog()
 
 
-class TestValidationError(object):
+class TestValidationError:
     """A container for tests relating to ValidationErrors."""
 
     def test_validation_error_init_no_name(self):
@@ -326,7 +321,7 @@ class TestValidationErrorLog(ValidationTestBase):  # pylint: disable=too-many-pu
         assert error_log == error_log_empty
 
 
-class TestValidationAuxiliaryData(object):
+class TestValidationAuxiliaryData:
     """A container for tests relating to auxiliary validation data."""
 
     def test_error_code_names(self):
@@ -540,7 +535,7 @@ class TestValidateIsXML(ValidationTestBase):
 
         assert result == error_log_empty
 
-    def test_xml_check_explicit_encoding_in_str_detailed_output(self, xml_str_explicit_encoding, error_log_empty):
+    def test_xml_check_explicit_encoding_in_str_detailed_output(self, xml_str_explicit_encoding):
         """Perform check to see whether a parameter is valid XML.
 
         The parameter is valid XML, but in a format that lxml does not support.
@@ -548,11 +543,8 @@ class TestValidateIsXML(ValidationTestBase):
         """
         result = iati.validator.validate_is_xml(xml_str_explicit_encoding)
 
-        if sys.version_info.major > 2:  # python2/3 compatibility: lxml acts differently at v2 to v3, so different checks need to be made for each major version
-            assert len(result) == 1
-            assert result.contains_error_called('err-encoding-in-str')
-        else:
-            assert result == error_log_empty
+        assert len(result) == 1
+        assert result.contains_error_called('err-encoding-in-str')
 
     def test_xml_check_valid_xml_comments_after_detailed_output(self, xml_str, str_not_xml, error_log_empty):
         """Perform check to see string a parameter is valid XML.
@@ -991,7 +983,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_valid(data, schema_sectors)
 
 
-class TestValidateRulesets(object):
+class TestValidateRulesets:
     """A container for tests relating to validation of Rulesets."""
 
     @pytest.mark.fixed_to_202

--- a/iati/tests/test_version.py
+++ b/iati/tests/test_version.py
@@ -7,7 +7,7 @@ import iati.tests.utilities
 from iati.tests.fixtures.versions import iativer, semver, split_decimal, split_iativer, split_semver
 
 
-class TestVersionInit(object):
+class TestVersionInit:
     """A container for tests relating to initialisation of Standard Versions."""
 
     def test_version_no_params(self):
@@ -92,7 +92,7 @@ class TestVersionInit(object):
         assert str(excinfo.value) == 'A valid version number must be specified.'
 
 
-class TestVersionComparison(object):
+class TestVersionComparison:
     """A container for tests relating to comparison between Standard Versions."""
 
     @pytest.fixture(params=[
@@ -163,7 +163,7 @@ class TestVersionComparison(object):
         assert result == should_pass
 
 
-class TestVersionModification(object):
+class TestVersionModification:
     """A container for tests relating to modifying Version Numbers after they are instantiated."""
 
     CHANGE_AMOUNT = 10
@@ -199,7 +199,7 @@ class TestVersionModification(object):
         setattr(std_ver_minor_inst_valid_single, attrib_name, not_int)
 
 
-class TestVersionRepresentation(object):
+class TestVersionRepresentation:
     """A container for tests relating to how Standard Versions are represented when output."""
 
     def test_iativer_string_output(self, std_ver_minor_uninst_valid_iativer_possible):
@@ -227,7 +227,7 @@ class TestVersionRepresentation(object):
         assert version.semver_str == std_ver_minor_uninst_valid_semver_possible
 
 
-class TestVersionBumping(object):
+class TestVersionBumping:
     """A container for tests relating to bumping of Version Numbers."""
 
     def test_version_bump_major(self, std_ver_minor_uninst_valid_semver_possible):
@@ -255,7 +255,7 @@ class TestVersionBumping(object):
         assert version.next_decimal() == next_minor_version
 
 
-class TestVersionImplementationDetailHiding(object):
+class TestVersionImplementationDetailHiding:
     """A container for tests relating to ensuring implementation detail is hidden.
 
     The implementation of the Version class makes use of a Semantic Versioning library by inheriting from a base class.
@@ -284,7 +284,7 @@ class TestVersionImplementationDetailHiding(object):
         assert std_ver_minor_inst_valid_possible.partial is True
 
 
-class TestVersionConstants(object):
+class TestVersionConstants:
     """A container for tests relating to constants that define useful groups of IATI version numbers."""
 
     @pytest.fixture(params=[
@@ -335,7 +335,7 @@ class TestVersionConstants(object):
         assert iati.version.STANDARD_VERSION_ANY != ''
 
 
-class TestVersionDecorators(object):
+class TestVersionDecorators:
     """A container for tests that cover all version decorators."""
 
     def func_with_no_args(self):
@@ -356,7 +356,7 @@ class TestVersionDecorators(object):
 
 
 # pylint: disable=protected-access
-class VersionSupportChecksBase(object):
+class VersionSupportChecksBase:
     """A container for functions and fixtures used to check version support.
 
     In their own class to reduce the number of public methods in the parent class below the linting limit of 20.
@@ -509,7 +509,7 @@ class TestVersionSupportChecks(VersionSupportChecksBase):
             possibly_version_func(std_ver_all_uninst_typeerr)
 
 
-class TestVersionNormalisation(object):
+class TestVersionNormalisation:
     """A container for tests relating to normalising how versions are passed into functions."""
 
     @iati.version.decimalise_integer
@@ -593,17 +593,10 @@ class TestVersionNormalisation(object):
         result = junk_ignoring_func(std_ver_all_uninst_mixederr)
 
         assert result is std_ver_all_uninst_mixederr
-        try:
-            assert (result == original_value) or isinstance(original_value, type(iter([]))) or math.isnan(original_value)
-        except TypeError:
-            # python 2/3 compatibility - identical context managers are not deemed to be equal at Python 2
-            import decimal
-            import sys
-            if not (sys.version_info[0] == 2 and isinstance(original_value, type(decimal.localcontext()))):
-                assert False
+        assert (result == original_value) or isinstance(original_value, type(iter([]))) or math.isnan(original_value)
 
 
-class TestVersionMajorMinorRelationship(object):
+class TestVersionMajorMinorRelationship:
     """A container for tests relating to the relationship between major and minor versions."""
 
     def test_versions_for_integer(self, std_ver_major_uninst_valid_known):

--- a/iati/tests/utilities.py
+++ b/iati/tests/utilities.py
@@ -1,6 +1,5 @@
 """A module containing utility constants and functions for tests."""
 import decimal
-import sys
 import iati.constants
 import iati.resources
 import iati.tests.resources
@@ -21,15 +20,9 @@ XML_TREE_VALID = iati.utilities.load_as_tree(iati.tests.resources.get_test_data_
 """An etree that is valid XML but not IATI XML."""
 
 
-_BYTES_VALS = [b'\x80abc', b'\x80abc']
-
-
-_BYTES_VALS = [b'\x80abc', b'\x80abc']
-
-
 TYPE_TEST_DATA = {
     'bool': [True, False],
-    'bytes': [val for val in _BYTES_VALS if sys.version_info.major > 2],  # python2/3 compatibility
+    'bytes': [b'\x80abc', b'\x80abc'],
     'bytearray': [bytearray.fromhex('2Ef0 F1f2  '), bytearray(b'Hi!'), bytearray(range(20))],
     'complex': [3453J, -35415J, 0J, complex(234, 681), complex(-768, 16078), complex(6187, -81), complex(-1867, -618)],
     'contextmanager': [decimal.localcontext()],
@@ -44,7 +37,7 @@ TYPE_TEST_DATA = {
     'other': [NotImplemented],
     'range': [range(3, 4)],
     'set': [set(range(20)), set(['hello', 23]), frozenset(range(20)), frozenset(['hello', 23])],
-    'str': ['\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394', 'This is a string'] + [val for val in _BYTES_VALS if sys.version_info.major == 2],  # python2.7 warning # pylint: disable=anomalous-unicode-escape-in-string
+    'str': ['\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394', 'This is a string'],
     'tuple': [(), (1, 2)],
     'type': [type(1), type('string')],
     'unicode': [],  # counts as a string, so moved there

--- a/iati/utilities.py
+++ b/iati/utilities.py
@@ -175,7 +175,7 @@ def load_as_bytes(path):
         bytes: The contents of the file at the specified location.
 
     Raises:
-        FileNotFoundError (python3) / IOError (python2): When a file at the specified path does not exist.
+        FileNotFoundError: When a file at the specified path does not exist.
 
     Todo:
         Ensure all reasonably possible OSErrors are documented here and in functions that call this.
@@ -197,7 +197,7 @@ def load_as_dataset(path):
         iati.Dataset: A Dataset object representing the contents of the file at the specified location.
 
     Raises:
-        FileNotFoundError (python3) / IOError (python2): When a file at the specified path does not exist.
+        FileNotFoundError: When a file at the specified path does not exist.
 
         ValueError: When a file at the specified path does not contain valid XML.
 
@@ -217,10 +217,10 @@ def load_as_string(path):
         path (str): An absolute (rather than relative) path to the file that is to be read in.
 
     Returns:
-        str (python3) / unicode (python2): The contents of the file at the specified location.
+        str: The contents of the file at the specified location.
 
     Raises:
-        FileNotFoundError (python3) / IOError (python2): When a file at the specified path does not exist.
+        FileNotFoundError: When a file at the specified path does not exist.
 
     """
     loaded_bytes = load_as_bytes(path)
@@ -233,9 +233,6 @@ def load_as_string(path):
         detected_info = chardet.detect(loaded_bytes[:25000])
         try:
             loaded_str = loaded_bytes.decode(detected_info['encoding'])
-            # in Python 2 it is necessary to strip the BOM when decoding from UTF-16BE
-            if detected_info['encoding'] == 'UTF-16' and loaded_str[:1] == u'\ufeff':
-                loaded_str = loaded_str[1:]
         except TypeError:
             raise ValueError('Could not detect encoding of file')
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -7,7 +7,7 @@ import iati.default
 import iati.resources
 
 
-class ValidationError(object):
+class ValidationError:
     """A base class to encapsulate information about Validation Errors."""
 
     # pylint: disable=too-many-instance-attributes
@@ -70,7 +70,7 @@ class ValidationError(object):
             pass
 
 
-class ValidationErrorLog(object):
+class ValidationErrorLog:
     """A container to keep track of a set of ValidationErrors.
 
     This acts as an iterable that ValidationErrors can be looped over.
@@ -733,11 +733,7 @@ def get_error_codes():
 
     # convert name of exception into reference to the relevant class
     for err in err_codes_dict.values():
-        # python2/3 have exceptions in different modules, though six and future do not appear to have a standard workaround for this
-        try:
-            err['base_exception'] = getattr(sys.modules['builtins'], err['base_exception'])
-        except KeyError:
-            err['base_exception'] = getattr(sys.modules['exceptions'], err['base_exception'])
+        err['base_exception'] = getattr(sys.modules['builtins'], err['base_exception'])
 
     return err_codes_dict
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,9 +20,6 @@ pytest==3.4.0 # rq.filter: <4.0
 pytest-cov==2.5.1 # rq.filter: <3.0
 pytest-xdist==1.22.0 # rq.filter: <2.0
 
-# python2/python3 compatibility library
-future==0.16.0 # rq.filter: <1.0
-
 #
 # distribution requirements
 #

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@ setup(
         'lxml==4.1.1',
         # YAML parsing for validation error codes
         'PyYAML==3.12',
-        # python2/python3 compatibility library
-        'six==1.11.0',
         # SemVer library
         'semantic_version==2.6.0'
         ],
@@ -29,7 +27,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
The reasons for removal are detailed in #301
The tests no longer pass when run with Python 2.7.

Further work could be undertaken to utilise a greater range of Python 3 features. This commit merely removes attempts to test at 2.7, as well as the shims to enable this.